### PR TITLE
fix `t8_free`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -54,7 +54,7 @@ macro T8_ASSERT(q)
 end
 
 function t8_free(ptr)
-  sc_free(t8_get_package_id(), ptr)
+  Libt8.sc_free(t8_get_package_id(), ptr)
 end
 
 # typedef int         (*t8_forest_adapt_t) (t8_forest_t forest,


### PR DESCRIPTION
`t8_free` calls `sc_free`, which is not `export`ed from `Libt8` anymore. Thus, I added the qualifier. I also increased the version number since it would be nice to get a new release including this fix.