### PR TITLE
Add non-public API functions.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -210,6 +210,7 @@ end
 # needed nevertheless by some application codes. This will be fixed resp. more
 # streamlined in future releases of t8code.
 
+export t8_forest_ghost_get_remotes
 function t8_forest_ghost_get_remotes(forest)
     num_remotes_ref = Ref{Cint}()
     remotes_ptr = @ccall T8code.Libt8.libt8.t8_forest_ghost_get_remotes(forest::t8_forest_t,
@@ -217,20 +218,24 @@ function t8_forest_ghost_get_remotes(forest)
     remotes = unsafe_wrap(Array, remotes_ptr, num_remotes_ref[])
 end
 
+export t8_forest_ghost_remote_first_elem
 function t8_forest_ghost_remote_first_elem(forest, remote)
     @ccall T8code.Libt8.libt8.t8_forest_ghost_remote_first_elem(forest::t8_forest_t,
                                                                 remote::Cint)::t8_locidx_t
 end
 
+export t8_forest_ghost_num_trees
 function t8_forest_ghost_num_trees(forest)
     @ccall T8code.Libt8.libt8.t8_forest_ghost_num_trees(forest::t8_forest_t)::t8_locidx_t
 end
 
+export t8_forest_ghost_get_tree_element_offset
 function t8_forest_ghost_get_tree_element_offset(forest, lghost_tree)
     @ccall T8code.Libt8.libt8.t8_forest_ghost_get_tree_element_offset(forest::t8_forest_t,
                                                                       lghost_tree::t8_locidx_t)::t8_locidx_t
 end
 
+export t8_forest_ghost_get_global_treeid
 function t8_forest_ghost_get_global_treeid(forest, lghost_tree)
     @ccall T8code.Libt8.libt8.t8_forest_ghost_get_global_treeid(forest::t8_forest_t,
                                                                 lghost_tree::t8_locidx_t)::t8_gloidx_t

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -202,4 +202,38 @@ function __init__()
     end
 end
 
+function t8_free(ptr)
+    T8code.Libt8.sc_free(t8_get_package_id(), ptr)
+end
+
+# Following functions are not part of the official public API of t8code but are
+# needed nevertheless by some application codes. This will be fixed resp. more
+# streamlined in future releases of t8code.
+
+function t8_forest_ghost_get_remotes(forest)
+    num_remotes_ref = Ref{Cint}()
+    remotes_ptr = @ccall T8code.Libt8.libt8.t8_forest_ghost_get_remotes(forest::t8_forest_t,
+                                                                        num_remotes_ref::Ptr{Cint})::Ptr{Cint}
+    remotes = unsafe_wrap(Array, remotes_ptr, num_remotes_ref[])
+end
+
+function t8_forest_ghost_remote_first_elem(forest, remote)
+    @ccall T8code.Libt8.libt8.t8_forest_ghost_remote_first_elem(forest::t8_forest_t,
+                                                                remote::Cint)::t8_locidx_t
+end
+
+function t8_forest_ghost_num_trees(forest)
+    @ccall T8code.Libt8.libt8.t8_forest_ghost_num_trees(forest::t8_forest_t)::t8_locidx_t
+end
+
+function t8_forest_ghost_get_tree_element_offset(forest, lghost_tree)
+    @ccall T8code.Libt8.libt8.t8_forest_ghost_get_tree_element_offset(forest::t8_forest_t,
+                                                                      lghost_tree::t8_locidx_t)::t8_locidx_t
+end
+
+function t8_forest_ghost_get_global_treeid(forest, lghost_tree)
+    @ccall T8code.Libt8.libt8.t8_forest_ghost_get_global_treeid(forest::t8_forest_t,
+                                                                lghost_tree::t8_locidx_t)::t8_gloidx_t
+end
+
 end


### PR DESCRIPTION
The added routines are not part of the public API of t8code but are needed nevertheless by applications codes such as Trixi.jl. This PR adds them manually. This will be fixed resp. streamelined in future t8code releases.