### PR TITLE
Add Aqua.jl tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # T8code.jl
 
 [![All Tests Status](https://github.com/DLR-AMR/T8code.jl/actions/workflows/test.yml/badge.svg)](https://github.com/DLR-AMR/T8code.jl/actions/workflows/test.yml)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
 
 

--- a/src/Libt8.jl
+++ b/src/Libt8.jl
@@ -1,6 +1,6 @@
 module Libt8
 
-using CEnum
+using CEnum: CEnum, @cenum
 
 to_c_type(t::Type) = t
 to_c_type_pairs(va_list) = map(enumerate(to_c_type.(va_list))) do (ind, type)
@@ -41,7 +41,7 @@ end
 const ptrdiff_t = Cptrdiff_t
 
 # Definitions used from MPI.jl
-using MPI: MPI, MPI_Datatype, MPI_Comm, MPI_Group, MPI_File
+using MPI: MPI, MPI_Datatype, MPI_Comm, MPI_File
 
 const MPI_COMM_WORLD = MPI.COMM_WORLD
 const MPI_COMM_SELF = MPI.COMM_SELF

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -1,7 +1,7 @@
 module T8code
 
 using Reexport: @reexport
-using Libdl
+using Libdl: Libdl
 
 using MPIPreferences: MPIPreferences
 # We need to load the preference setting from here and not from `Libt8.jl`

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,9 +1,11 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.7, 0.8"
 MPI = "0.20"
 MPIPreferences = "0.1.3"
 Test = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ import MPIPreferences
 @info "Testing T8code.jl with" MPIPreferences.binary MPIPreferences.abi
 
 @time @testset "T8code.jl tests" begin
+    include("test_aqua.jl")
     # For some weird reason, the MPI tests must come first since they fail
     # otherwise with a custom MPI installation.
     @time @testset "MPI" begin

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,11 @@
+module TestAqua
+
+using Aqua
+using Test
+using T8code
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(T8code)
+end
+
+end #module


### PR DESCRIPTION
I added [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) tests. Additionally, I used [ExplicitImports.jl](https://github.com/ericphanson/ExplicitImports.jl) to detect stale explicit imports and implicit imports. However, we cannot use it as regression test because it requires Julia v1.7, but T8code.jl supports Julia v1.6 (and CI runs on Julia v1.6).