### PR TITLE
export `@t8_replace_callback`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -181,6 +181,12 @@ end
 #                                           const int is_family,
 #                                           const int num_elements,
 #                                           t8_element_t *elements[]);
+"""
+    @t8_adapt_callback(callback)
+
+Wrap the Julia function `callback` in an `@cfunction` with the appropriate
+signature required for callback functions in [`t8_forest_adapt`](@ref).
+"""
 macro t8_adapt_callback(callback)
     :(@cfunction($callback, Cint,
                  (Ptr{t8_forest}, Ptr{t8_forest}, t8_locidx_t, t8_locidx_t,
@@ -195,6 +201,12 @@ end
 #                                             t8_locidx_t first_outgoing,
 #                                             int num_incoming,
 #                                             t8_locidx_t first_incoming);
+"""
+    @t8_replace_callback(callback)
+
+Wrap the Julia function `callback` in an `@cfunction` with the appropriate
+signature required for callback functions in [`t8_forest_iterate_replace`](@ref).
+"""
 macro t8_replace_callback(callback)
     :(@cfunction($callback, Cvoid,
                  (Ptr{Cvoid}, Ptr{Cvoid}, t8_locidx_t, Ptr{Cvoid}, Cint, Cint, t8_locidx_t,

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -18,6 +18,7 @@ include("Libt8.jl")
 @reexport using .Libt8
 
 export @t8_adapt_callback
+export @t8_replace_callback
 export @T8_ASSERT
 export t8_free
 


### PR DESCRIPTION
This macro is similar to the exported macro `@t8_adapt_callback`. Thus, I think it's useful to `export` it, too.