### PR TITLE
Fix: generalize hard-coded `Cint` to `MPI_Comm` in `t8_forest_get_mpicomm`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/dev/fixes.sh
+++ b/dev/fixes.sh
@@ -9,6 +9,8 @@ LIB_JL="Libt8.jl"
 
 set -euxo pipefail
 
+sed -i "s/using CEnum/using CEnum: @cenum/g" "${LIB_JL}"
+
 # Remove Fortran macros
 sed -i "/INTEGER(KIND/d" "${LIB_JL}"
 
@@ -24,6 +26,8 @@ sed -i "s/\binternode::Ptr{Cint}/internode::Ptr{MPI_Comm}/g" "${LIB_JL}"
 sed -i "s/mpifile::Cint/mpifile::MPI_File/g" "${LIB_JL}"
 sed -i "s/mpidatatype::Cint/mpidatatype::MPI_Datatype/g" "${LIB_JL}"
 sed -i "s/\bt::Cint/t::MPI_Datatype/g" "${LIB_JL}"
+
+sed -i "s/t8_forest_get_mpicomm\(forest::t8_forest_t\)::Cint/t8_forest_get_mpicomm(forest::t8_forest_t)::MPI_Comm/g" "${LIB_JL}"
 
 sed -i "s/forest::Cint/forest::t8_forest_t/" "${LIB_JL}"
 

--- a/dev/fixes.sh
+++ b/dev/fixes.sh
@@ -30,7 +30,7 @@ sed -i "s/\bt::Cint/t::MPI_Datatype/g" "${LIB_JL}"
 sed -i "s/t8_forest_get_mpicomm\(forest::t8_forest_t\)::Cint/t8_forest_get_mpicomm(forest::t8_forest_t)::MPI_Comm/g" "${LIB_JL}"
 
 sed -i "s/forest::Cint/forest::t8_forest_t/" "${LIB_JL}"
-
+sed -i "s/cmesh::Cint/cmesh::t8_cmesh_t/" "${LIB_JL}"
 
 # Use libsc for `sc_*` functions
 sed -i "s/libt8\.sc_/libsc.sc_/g" "${LIB_JL}"

--- a/src/Libt8.jl
+++ b/src/Libt8.jl
@@ -17844,7 +17844,7 @@ void t8_geom_load_tree_data_vertices (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, con
 ```
 """
 function t8_geom_load_tree_data_vertices(cmesh, gtreeid, user_data)
-    @ccall libt8.t8_geom_load_tree_data_vertices(cmesh::Cint, gtreeid::Cint, user_data::Ptr{Ptr{Cvoid}})::Cvoid
+    @ccall libt8.t8_geom_load_tree_data_vertices(cmesh::t8_cmesh_t, gtreeid::Cint, user_data::Ptr{Ptr{Cvoid}})::Cvoid
 end
 
 """

--- a/src/Libt8.jl
+++ b/src/Libt8.jl
@@ -41,7 +41,7 @@ end
 const ptrdiff_t = Cptrdiff_t
 
 # Definitions used from MPI.jl
-using MPI: MPI, MPI_Datatype, MPI_Comm, MPI_Group, MPI_File
+using MPI: MPI, MPI_Datatype, MPI_Comm, MPI_File
 
 const MPI_COMM_WORLD = MPI.COMM_WORLD
 const MPI_COMM_SELF = MPI.COMM_SELF
@@ -13125,7 +13125,7 @@ end
 """
     t8_stash_attribute_sort(stash)
 
-Sort the attributes array of a stash in the order (treeid, packageid, key) *
+Sort the attributes array of a stash in the order (treeid, package_id, key) *
 
 # Arguments
 * `stash`:\\[in,out\\] The stash to be considered.
@@ -15698,7 +15698,7 @@ sc_MPI_Comm t8_forest_get_mpicomm (const t8_forest_t forest);
 ```
 """
 function t8_forest_get_mpicomm(forest)
-    @ccall libt8.t8_forest_get_mpicomm(forest::t8_forest_t)::Cint
+    @ccall libt8.t8_forest_get_mpicomm(forest::t8_forest_t)::MPI_Comm
 end
 
 """


### PR DESCRIPTION
This patch generalizes the return value of `t8_forest_get_mpicomm`. This is crucial when using OpenMPI as system library. The MPI Communicator handle is not an integer but a pointer to a struct.

Along the way, I also added other minor improvements.