### PR TITLE
Revert release 0.7.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,6 @@ on:
       - '.github/workflows/CompatHelper.yml'
       - '.github/workflows/TagBot.yml'
       - '.gitignore'
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
 
 # Cancel redundant CI tests automatically
 concurrency:
@@ -42,21 +35,16 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        julia-version: ['1.9', '1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest]
-        include:
-        - julia-version: '1.9'
-          julia-arch: 'default'
-          os: macos-latest
-        - julia-version: '1'
-          julia-arch: 'default'
-          os: macos-latest
-        - julia-version: 'nightly'
-          julia-arch: 'default'
-          os: macos-latest
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+          - os: windows-latest
+            julia-arch: x86
+
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
@@ -67,8 +55,3 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         # with:
         #   annotate: true
-        continue-on-error: false
-      # Enable tmate debugging of manually-triggered workflows if the input option was provided
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.typos.toml
+++ b/.typos.toml
@@ -3,5 +3,4 @@ consistend = "consistend" # is used in API function names...
 Inout = "Inout"
 leafs = "leafs"
 packageid = "packageid"
-WRONLY = "WRONLY" # used in "sc_MPI_MODE_WRONLY"
 iz = "iz"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,7 +11,6 @@ hereby called the "T8code Authors".
 The following people contributed major additions or modifications to T8code.jl:
 
 - [Joshua Lampert](https://github.com/JoshuaLampert).
-- [Benedict Geihe](https://github.com/benegee).
 
 The software is an adapted fork of P4est.jl which is maintained by
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.7.6-DEV"
+version = "0.7.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.7.5-DEV"
+version = "0.7.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -22,4 +22,4 @@ Preferences = "1.2.1"
 Reexport = "0.2, 1.0"
 UUIDs = "1"
 julia = "1.6"
-t8code_jll = "=4.0.1"
+t8code_jll = "=3.0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.7.5"
+version = "0.7.5-DEV"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "T8code"
 uuid = "d0cc0030-9a40-4274-8435-baadcfd54fa1"
 authors = ["Johannes Markert <johannes.markert@dlr.de>"]
-version = "0.7.4"
+version = "0.7.6"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,94 +1,21 @@
-# Generating Julia bindings of `t8code` with `Clang.jl`
+# Building Julia bindings of `t8code` with Clang.jl
 
-Working with or deploying a new release of `T8code.jl` involves creating a new build of the
-binary package `t8code_jll.jl`, and generating new bindings in `T8code.jl`.
-
-
-## Updating `t8code_jll.jl`
-
-### For local development
-
-If you are developing `t8code`, you will probably want to use your locally compiled version
-instead of `t8code_jll.jl`, as documented here:
-https://github.com/DLR-AMR/T8code.jl?tab=readme-ov-file#using-a-custom-version-of-mpi-andor-t8code
-
-
-### For deployment
-
-If you want to provide a new `t8code` release for the Julia community, you need to trigger a
-new build of the `t8code_jll.jl` bindary package. Building the binaries happens via
-BinaryBuilder, documented here:
-https://docs.binarybuilder.org/stable/.
-It boils down to checking out
-https://github.com/JuliaPackaging/Yggdrasil/tree/master/T/t8code,
-editing `build_tarballs.jl` to at least reflect the latest version, tarball URL, and hash,
-committing, and opening a pull request.
-
-Even a draft PR will already trigger the buildkite pipelines. Check the builds for any
-errors. Successful runs will produce the binary packages as artifacts. You can find an URL
-to such an artifact in the buildkite output, along with its tree hash and SHA256 hash,
-which can be used in `Artifacts.toml` described below.
-
-If you instead want to run BinaryBuilder locally you can do so by executing
-
-```shell
-julia build_tarballs.jl --debug --verbose x86_64-linux-gnu --deploy=local
-```
-
-You can use any other eligible platform triple instead of `x86_64-linux-gnu`. Adding
-`--deploy=local` will add the created binaries to your local Julia artifacts folder.
-
-
-## Updating `Tcode.jl`
-
-Bindings are created using `Clang.jl`. The general process is as follows:
+The general process for creating bindings with Clang.jl is as follows:
 
 1. Create a `generator.jl` file with the relevant Julia code (not a lot).
 2. Create a corresponding `generator.toml` file with certain settings.
-3. Run `julia generator.jl` to create a new file `Libt8.jl`.
+3. Run `julia generator.jl` to create new file `Libt8.jl`.
 4. Apply manual fixes using `./fixes.sh`
 5. Run `julia Libt8.jl`.
 6. Get error(s).
-7. Try to finagle something with `generator.toml`, `prologue.jl`, `epilogue.jl`,
+7. Try to finagle something with `generator.toml`, `prologue.jl`/`epilogue.jl`,
    or `fixes.sh`.
 8. Go back to 3.
 
-Start using the current setup (steps 1 and 2).
-The crucial ingredients are the `t8code` header files, which are expected in a subdirectory
-`t8code_include` of the folder of this , i.e., the `dev` subfolder. You have the following
-options:
-- If you are developing `t8code` locally, you can copy and rename `t8code`'s `include`
-  directory from its current prefix path. You will have to comment lines 5 and 6 (dealing with artifacts) in `generator.jl` then.
-- If your pull request to Yggdrasil has already been merged, you can find the newly built
-  binary packages at https://github.com/JuliaBinaryWrappers/t8code_jll.jl/releases. Copy an
-  entry of https://github.com/JuliaBinaryWrappers/t8code_jll.jl/blob/main/Artifacts.toml to
-  the local `Artifacts.toml` file. The exact choice of the platform triplet should not
-  matter since we use only the header files which are the same on each system. However,
-  they may matter in the presence of MPI headers since we apply some custom `fixes.sh`
-  afterwards.
-- If your pull request has not yet been accepted, you can instead use artifacts of the
-  buildkite pipeline, see above.  
-- If you ran BindaryBuilder locally, you can somehow use your local artifacts. But how?
-
-In any case run
+To generate new bindings, run
 ```shell
 julia --project generator.jl && ./fixes.sh
 ```
-next (steps 3 and 4). If all goes well and no error is thrown, try running `julia Libt8.jl`
-(step 5). Then, move the new `Libt8.jl` file to `src/` and adapt the compat entry in
-`Project.toml` to reflect the new version of `t8code_jll.jl`.
-At this point you can test your new `T8code.jl` package locally, e.g. by creating a
-subdirectory `run` at the `T8code.jl` root folder, and from there executing
+to create a new `Libt8.jl` file.
 
-```shell
-julia --project=.
-
-julia> using Pkg
-julia> Pkg.develop(path="..")
-julia> Pkg.test("T8code")
-```
-
-If anything fails, you might have to update the generator workflow (step 7) or start
-debugging the tests. If all goes well, go ahead and open a pull request.
-Once this pull request has been merged, downstream packages can start adopting your new
-t8code release!
+More information can be found in https://github.com/trixi-framework/P4est.jl

--- a/dev/fixes.sh
+++ b/dev/fixes.sh
@@ -9,15 +9,27 @@ LIB_JL="Libt8.jl"
 
 set -euxo pipefail
 
+sed -i "s/using CEnum/using CEnum: @cenum/g" "${LIB_JL}"
+
+# Remove Fortran macros
+sed -i "/INTEGER(KIND/d" "${LIB_JL}"
+
+# Remove other probably unused macros
+sed -i "/P4EST_NOTICE/d" "${LIB_JL}"
+sed -i "/P4EST_GLOBAL_NOTICE/d" "${LIB_JL}"
+
 # Fix MPI types that have been wrongly converted to Julia types
 sed -i "s/mpicomm::Cint/mpicomm::MPI_Comm/g" "${LIB_JL}"
 sed -i "s/\bcomm::Cint/comm::MPI_Comm/g" "${LIB_JL}"
 sed -i "s/\bintranode::Ptr{Cint}/intranode::Ptr{MPI_Comm}/g" "${LIB_JL}"
 sed -i "s/\binternode::Ptr{Cint}/internode::Ptr{MPI_Comm}/g" "${LIB_JL}"
 sed -i "s/mpifile::Cint/mpifile::MPI_File/g" "${LIB_JL}"
+sed -i "s/mpidatatype::Cint/mpidatatype::MPI_Datatype/g" "${LIB_JL}"
+sed -i "s/\bt::Cint/t::MPI_Datatype/g" "${LIB_JL}"
 
-# Change return type of `t8_forest_get_mpicomm``from `Cint` to `MPI_Comm`
-sed -i "s/t8_forest_get_mpicomm(forest::t8_forest_t)::Cint/t8_forest_get_mpicomm(forest::t8_forest_t)::MPI_Comm/g" "${LIB_JL}"
+sed -i "s/t8_forest_get_mpicomm\(forest::t8_forest_t\)::Cint/t8_forest_get_mpicomm(forest::t8_forest_t)::MPI_Comm/g" "${LIB_JL}"
+
+sed -i "s/forest::Cint/forest::t8_forest_t/" "${LIB_JL}"
 
 # Use libsc for `sc_*` functions
 sed -i "s/libt8\.sc_/libsc.sc_/g" "${LIB_JL}"
@@ -31,11 +43,92 @@ sed -i "s/libt8\.p6est_/libp4est.p6est_/g" "${LIB_JL}"
 # Use libp4est for `p8est_*` functions
 sed -i "s/libt8\.p8est_/libp4est.p8est_/g" "${LIB_JL}"
 
-# Remove struct t8_forest definition and replace by forward declaration
-sed -i -z 's/\nstruct t8_forest.*stats_computed::Cint\nend/\n# This struct is not supposed to be read and modified directly.\n# Besides, there is a circular dependency with `t8_forest_t`\n# leading to an error output by Julia.\nmutable struct t8_forest end/g' "${LIB_JL}"
 
-# Fix forest type
-sed -i "s/forest::Cint/forest::t8_forest_t/" "${LIB_JL}"
+# Fix type of `sc_array` field `array`
+sed -i "s/array::Cstring/array::Ptr{Int8}/g" "${LIB_JL}"
 
-# Rename remaining MPI macros
+# Remove cross references that are not found
+sed -i "s/\[\`p4est\`](@ref)/\`p4est\`/g" "${LIB_JL}"
+sed -i "s/\[\`p6est\`](@ref)/\`p6est\`/g" "${LIB_JL}"
+sed -i "s/\[\`p8est\`](@ref)/\`p8est\`/g" "${LIB_JL}"
+sed -i "s/\[\`P4EST_QMAXLEVEL\`](@ref)/\`P4EST_QMAXLEVEL\`/g" "${LIB_JL}"
+sed -i "s/\[\`P8EST_QMAXLEVEL\`](@ref)/\`P8EST_QMAXLEVEL\`/g" "${LIB_JL}"
+sed -i "s/\[\`P4EST_CONN_DISK_PERIODIC\`](@ref)/\`P4EST_CONN_DISK_PERIODIC\`/g" "${LIB_JL}"
+sed -i "s/\[\`p8est_iter_corner_side_t\`](@ref)/\`p8est_iter_corner_side_t\`/g" "${LIB_JL}"
+sed -i "s/\[\`p8est_iter_edge_side_t\`](@ref)/\`p8est_iter_edge_side_t\`/g" "${LIB_JL}"
+sed -i "s/\[\`p4est_corner_info_t\`](@ref)/\`p4est_corner_info_t\`/g" "${LIB_JL}"
+sed -i "s/\[\`p8est_corner_info_t\`](@ref)/\`p8est_corner_info_t\`/g" "${LIB_JL}"
+sed -i "s/\[\`p8est_edge_info_t\`](@ref)/\`p8est_edge_info_t\`/g" "${LIB_JL}"
+sed -i "s/\[\`sc_MPI_Barrier\`](@ref)/\`sc_MPI_Barrier\`/g" "${LIB_JL}"
+sed -i "s/\[\`sc_MPI_COMM_NULL\`](@ref)/\`sc_MPI_COMM_NULL\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_CHECK_ABORT\`](@ref)/\`SC_CHECK_ABORT\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LP_DEFAULT\`](@ref)/\`SC_LP_DEFAULT\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LC_NORMAL\`](@ref)/\`SC_LC_NORMAL\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LC_GLOBAL\`](@ref)/\`SC_LC_GLOBAL\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LP_ALWAYS\`](@ref)/\`SC_LP_ALWAYS\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LP_SILENT\`](@ref)/\`SC_LP_SILENT\`/g" "${LIB_JL}"
+sed -i "s/\[\`SC_LP_THRESHOLD\`](@ref)/\`SC_LP_THRESHOLD\`/g" "${LIB_JL}"
+sed -i "s/\[\`sc_logf\`](@ref)/\`sc_logf\`/g" "${LIB_JL}"
+
+# For nicer docstrings
+sed -i "s/\`p4est\`.h/\`p4est.h\`/g" "${LIB_JL}"
+sed -i "s/\`p8est\`.h/\`p8est.h\`/g" "${LIB_JL}"
+
+sed -i "/_sc_const/d" "${LIB_JL}"
+sed -i "/_sc_restrict/d" "${LIB_JL}"
+sed -i "/sc_keyvalue_t/d" "${LIB_JL}"
+
+sed -i "/T8_VERSION_POINT/d" "${LIB_JL}"
+sed -i "/P4EST_VERSION_POINT/d" "${LIB_JL}"
+
+sed -i "/P4EST_GLOBAL_NOTICE/d" "${LIB_JL}"
+sed -i "/P4EST_NOTICE/d" "${LIB_JL}"
+
+sed -i "/P4EST_F90_QCOORD/d" "${LIB_JL}"
+sed -i "/P4EST_F90_TOPIDX/d" "${LIB_JL}"
+sed -i "/P4EST_F90_LOCIDX/d" "${LIB_JL}"
+sed -i "/P4EST_F90_GLOIDX/d" "${LIB_JL}"
+
+sed -i "/MPI_ERR_GROUP/d" "${LIB_JL}"
+
+sed -i "/SC_VERSION_POINT/d" "${LIB_JL}"
+
+sed -i "/sc_MPI_PACKED/d" "${LIB_JL}"
+sed -i "/sc_MPI_Pack/d" "${LIB_JL}"
+sed -i "/sc_MPI_Unpack/d" "${LIB_JL}"
+
+sed -i "/= MPI_MODE_/d" "${LIB_JL}"
+sed -i "/= MPI_SEEK_/d" "${LIB_JL}"
+sed -i "/= MPI_ERR_/d" "${LIB_JL}"
+sed -i "/= MPI_MAX_/d" "${LIB_JL}"
+sed -i "/= MPI_Type_/d" "${LIB_JL}"
+sed -i "/= MPI_Offset/d" "${LIB_JL}"
+sed -i "/= MPI_File_/d" "${LIB_JL}"
+
 sed -i "s/= MPI_/= MPI./" "${LIB_JL}"
+
+sed -i "s/packageid/package_id/" "${LIB_JL}"
+
+cat << EOT >&2
+
+# !!!!!! #
+# !!!!!! #
+
+# Manual fix. #
+
+Additionally, comment out
+
+  struct t8_forest
+    [...]
+  end
+
+and add
+
+  mutable struct t8_forest end
+
+in order to avoid error output due to
+circular dependency of 't8_forest_t'.
+
+# !!!!!! #
+# !!!!!! #
+EOT

--- a/dev/generator.jl
+++ b/dev/generator.jl
@@ -2,13 +2,23 @@ using Pkg
 Pkg.activate(@__DIR__)
 Pkg.instantiate()
 
-# This loads the artifact described in `Artifacts.toml`.
-# See README.md for instructions on how to update.
 using Artifacts
 cp(joinpath(artifact"t8code", "include"), "t8code_include"; force = true)
 
 using Glob
+
+# This loads the artifact described in `P4est/dev/Artifacts.toml`.
+# When a new release of P4est_jll.jl is created and you would like to update
+# the headers, you can copy one of the entries of
+# https://github.com/JuliaBinaryWrappers/P4est_jll.jl/blob/main/Artifacts.toml
+# to this file. Here, we chose the version
+# linux - x86_64 - glibc - mpich
+# The exact choice should not matter since we use only the header files which
+# are the same on each system. However, they may matter in the presence of
+# MPI headers since we apply some custom `fixes.sh` afterwards.
+
 using Clang.Generators
+# using Clang.LibClang.Clang_jll  # replace this with your jll package
 
 cd(@__DIR__)
 

--- a/dev/generator.toml
+++ b/dev/generator.toml
@@ -1,6 +1,3 @@
-# This was taken from
-# https://github.com/JuliaInterop/Clang.jl/blob/master/gen/generator.toml
-
 [general]
 # it could also be an expression as long as `Meta.parse` can parse this string successfully.
 # basically, it should be the `expression` in the following code:
@@ -31,14 +28,15 @@ module_name = "Libt8"
 # if this entry is not empty, the generator will print the code below to the `output_file_path`.
 # using jll_pkg_name
 # export jll_pkg_name
-# We do not set the option `jll_pkg_name` here since we want to customize it in prologue.jl.
-# jll_pkg_name = "t8code_jll"
+# We do not set this option since we want to customize it in prologue.jl.
+# jll_pkg_name = "P4est_jll"
 jll_pkg_name = ""
 
 # for packages that have extra JLL package dependencies
 jll_pkg_extra = []
 
 # identifiers that starts with the string listed in this entry will be exported.
+# export_symbol_prefixes = ["t8_", "p4est_", "p6est_", "p8est_", "sc_", "T8_", "P4EST_", "P6EST_", "P8EST_", "SC_"]
 export_symbol_prefixes = ["t8_", "T8_"]
 
 # the code in the following file will be copy-pasted to `output_file_path` before the generated code.
@@ -47,43 +45,28 @@ prologue_file_path = "./prologue.jl"
 
 # the code in the following file will be copy-pasted to `output_file_path` after the generated code.
 # this is often used for applying custom patches.
-epilogue_file_path = ""
+epilogue_file_path = "./epilogue.jl"
 
 # node with an id in the `output_ignorelist` will be ignored in the printing passes.
 # this is very useful for custom editing.
-# we use this to exclude everything which is not required and causes errors
 output_ignorelist = [
   "_sc_restrict",
-  "SC_GCC_VERSION",
+  "sc_extern_c_hack_3",
+  "sc_extern_c_hack_4",
   "SC_EXTERN_C_BEGIN",
   "SC_EXTERN_C_END",
+  "SC_GCC_VERSION",
+  "PLATFORM_COMPILER_VERSION",
+  "__PLATFORM_COMPILER_GNU_VERSION_STR",
+  "_p4est_const",
+  "sc_MPI_2INT",
   "sc_MPI_SUCCESS",
-  "sc_MPI_ERR_ARG",
-  "sc_MPI_ERR_COUNT",
-  "sc_MPI_ERR_UNKNOWN",
   "sc_MPI_ERR_OTHER",
-  "sc_MPI_ERR_NO_MEM",
-  "sc_MPI_MAX_ERROR_STRING",
-  "sc_MPI_ERR_FILE",
-  "sc_MPI_ERR_NOT_SAME",
-  "sc_MPI_ERR_AMODE",
-  "sc_MPI_ERR_UNSUPPORTED_DATAREP",
-  "sc_MPI_ERR_UNSUPPORTED_OPERATION",
-  "sc_MPI_ERR_NO_SUCH_FILE",
-  "sc_MPI_ERR_FILE_EXISTS",
-  "sc_MPI_ERR_BAD_FILE",
-  "sc_MPI_ERR_ACCESS",
-  "sc_MPI_ERR_NO_SPACE",
-  "sc_MPI_ERR_QUOTA",
-  "sc_MPI_ERR_READ_ONLY",
-  "sc_MPI_ERR_FILE_IN_USE",
-  "sc_MPI_ERR_DUP_DATAREP",
-  "sc_MPI_ERR_CONVERSION",
-  "sc_MPI_ERR_IO",
-  "sc_MPI_ERR_LASTCODE",
-  "sc_MPI_Aint",
   "sc_MPI_COMM_NULL",
+  # "sc_MPI_COMM_WORLD",
+  # "sc_MPI_COMM_SELF",
   "sc_MPI_COMM_TYPE_SHARED",
+  "sc_MPI_GROUP",
   "sc_MPI_GROUP_NULL",
   "sc_MPI_GROUP_EMPTY",
   "sc_MPI_IDENT",
@@ -95,11 +78,24 @@ output_ignorelist = [
   "sc_MPI_STATUS_IGNORE",
   "sc_MPI_STATUSES_IGNORE",
   "sc_MPI_REQUEST_NULL",
+  "sc_MPI_INFO_NULL",
   "sc_MPI_DATATYPE_NULL",
+  # "sc_MPI_CHAR",
+  # "sc_MPI_SIGNED_CHAR",
+  # "sc_MPI_UNSIGNED_CHAR",
+  # "sc_MPI_BYTE",
+  # "sc_MPI_SHORT",
+  # "sc_MPI_UNSIGNED_SHORT",
+  # "sc_MPI_INT",
+  # "sc_MPI_UNSIGNED",
+  # "sc_MPI_LONG",
+  # "sc_MPI_UNSIGNED_LONG",
+  # "sc_MPI_LONG_LONG_INT",
+  # "sc_MPI_UNSIGNED_LONG_LONG",
+  # "sc_MPI_FLOAT",
+  # "sc_MPI_DOUBLE",
   "sc_MPI_LONG_DOUBLE",
-  "sc_MPI_2INT",
-  "sc_MPI_DOUBLE_INT",
-  "sc_MPI_PACKED",
+  "sc_MPI_Op",
   "sc_MPI_OP_NULL",
   "sc_MPI_MAX",
   "sc_MPI_MIN",
@@ -116,10 +112,7 @@ output_ignorelist = [
   "sc_MPI_PROD",
   "sc_MPI_UNDEFINED",
   "sc_MPI_KEYVAL_INVALID",
-  "sc_MPI_Op",
-  "sc_MPI_Request",
   "sc_MPI_Status",
-  "sc_MPI_INFO_NULL",
   "sc_MPI_Init",
   "sc_MPI_Finalize",
   "sc_MPI_Abort",
@@ -162,6 +155,7 @@ output_ignorelist = [
   "sc_MPI_Allreduce",
   "sc_MPI_Scan",
   "sc_MPI_Exscan",
+  "sc_MPI_Request",
   "sc_MPI_Recv",
   "sc_MPI_Irecv",
   "sc_MPI_Send",
@@ -173,75 +167,11 @@ output_ignorelist = [
   "sc_MPI_Wait",
   "sc_MPI_Waitsome",
   "sc_MPI_Waitall",
-  "sc_MPI_Type_size",
-  "sc_MPI_Pack",
-  "sc_MPI_Unpack",
-  "sc_MPI_Pack_size",
-  "sc_MPI_Aint_diff",
+  "sc_MPI_Init_thread",
   "sc_MPI_THREAD_SINGLE",
   "sc_MPI_THREAD_FUNNELED",
   "sc_MPI_THREAD_SERIALIZED",
   "sc_MPI_THREAD_MULTIPLE",
-  "sc_MPI_Init_thread",
-  "sc_MPI_MODE_RDONLY",
-  "sc_MPI_MODE_RDWR",
-  "sc_MPI_MODE_WRONLY",
-  "sc_MPI_MODE_CREATE",
-  "sc_MPI_MODE_EXCL",
-  "sc_MPI_MODE_DELETE_ON_CLOSE",
-  "sc_MPI_MODE_UNIQUE_OPEN",
-  "sc_MPI_MODE_SEQUENTIAL",
-  "sc_MPI_MODE_APPEND",
-  "sc_MPI_SEEK_SET",
-  "sc_MPI_SEEK_CUR",
-  "sc_MPI_SEEK_END",
-  "sc_MPI_Offset",
-  "sc_MPI_File_open",
-  "sc_MPI_File_close",
-  "sc_MPI_File_get_view",
-  "sc_MPI_File_set_view",
-  "sc_MPI_File_write_all",
-  "sc_MPI_File_read_all",
-  "sc_MPI_File_write_at_all",
-  "sc_MPI_File_read_at_all",
-  "sc_MPI_File_get_size",
-  "sc_MPI_File_set_size",
-  "t8_const",
-  "t8_restrict",
-  "T8_ECLASS_TO_DIMENSION_VALUES",
-  "T8_ECLASS_NUM_FACES_VALUES",
-  "T8_ECLASS_MAX_NUM_FACES_VALUES",
-  "T8_ECLASS_MAX_NUM_CHILDREN_VALUES",
-  "T8_REFERENCE_FACE_NORMAL_TET_VALUES",
-  "T8_ECLASS_NUM_VERTICES_VALUES",
-  "T8_ECLASS_NUM_EDGES_VALUES",
-  "T8_ECLASS_VTK_TYPE_VALUES",
-  "T8_ECLASS_TO_STRING_VALUES",
-  "T8_VERSION_POINT_STRING",
-  "T8_LOCIDX_FORMAT",
-  "T8_GLOIDX_FORMAT",
-  "T8_LINEARIDX_FORMAT",
-  "T8_WITH_DEBUG",
-  "T8_WITH_VTK",
-  "T8_WITH_NETCDF",
-  "T8_WITH_NETCDF_PAR",
-  "T8_WITH_OCC",
-  "T8_WITH_METIS",
-  "T8_WITH_MPI",
-  "T8_WITH_MPIIO",
-  "T8_WITH_FORTRAN",
-  "T8_WITH_CPPSTD",
-  "T8_WITH_MODDIR",
-  "T8_WITH_CUSTOM_TEST_COMMAND",
-  "_p4est_const",
-  "P4EST_F90_QCOORD",
-  "P4EST_F90_TOPIDX",
-  "P4EST_F90_LOCIDX",
-  "P4EST_F90_GLOIDX",
-  "P4EST_GLOBAL_NOTICE",
-  "P4EST_GLOBAL_NOTICEF",
-  "P4EST_NOTICE",
-  "P4EST_NOTICEF",
 ]
 
 # Julia's `@enum` do not allow duplicated values, so by default, C enums are translated to
@@ -265,9 +195,6 @@ use_deterministic_symbol = true
 # if you'd like to generate all of the symbols in the system headers, please set this option to false.
 is_local_header_only = true
 
-# set this option to false if you'd like to ignore the symbols(even if necessary) in the system headers.
-generate_isystem_symbols = true
-
 # if this option is set to true, C code with a style of
 # ```c
 # typedef struct {
@@ -288,9 +215,6 @@ generate_isystem_symbols = true
 # const my_struct = var"##Ctag#NUM"
 # ```
 smart_de_anonymize = true
-
-# if set to true, static functions will be ignored
-skip_static_functions = false
 
 # EXPERIMENTAL
 # if this option is set to true, those structs that are not necessary to be an
@@ -318,17 +242,8 @@ auto_mutability_includelist = []
 # note: by default, Clang only parses doxygen comment, pass `-fparse-all-comments` to Clang in order to parse non-doxygen comments.
 extract_c_comment_style = "doxygen"
 
-# Pass a function to explicitly generate documentation. It will be called like
-# `callback_documentation(node::ExprNode, doc::Vector{String})` if it is
-# set. The `doc` argument will contain the docs parsed from the headers if
-# `extract_c_comment_style` is set, otherwise it will be an empty vector.
-#
-# Do *not* set this in the TOML file, it should be set in the generator script
-# to a function that takes in an ExprNode and returns a String[] (string
-# vector).
-# callback_documentation = ""
-
 # if set to true, single line comment will be printed as """comment""" instead of """\ncomment\n"""
+# fold_single_line_comment = false
 fold_single_line_comment = true
 
 # if set to "outofline", documentation of struct fields will be collected at the "Fields" section of the struct
@@ -362,14 +277,9 @@ opaque_as_mutable_struct = true
 use_ccall_macro = true
 
 # if true, variadic functions are wrapped with `@ccall` macro. Otherwise variadic functions are ignored.
-# needed e.g. for t8_global_productionf
 wrap_variadic_function = true
 
-# Generate getproperty/setproperty! methods for the types in the following list.
-# Warning: the generated methods will only work on the architecture that they
-# were generated on. i.e. if you generate them on a 64bit machine they are not
-# guaranteed to work on 32bit machines. See
-# https://github.com/JuliaInterop/Clang.jl/issues/512 for more details.
+# generate getproperty/setproperty! methods for the types in the following list
 field_access_method_list = []
 
 # the generator will prefix the function argument names in the following list with a "_" to
@@ -381,13 +291,21 @@ function_argument_conflict_symbols = []
 add_record_constructors = []
 
 [codegen.macro]
-# it's highly recommended to set this entry to "basic".
+# it‘s highly recommended to set this entry to "basic".
 # if you'd like to skip all of the macros, please set this entry to "disable".
 # if you'd like to translate function-like macros to Julia, please set this entry to "aggressive".
 macro_mode = "basic"
 
 # function-like macros in the following list will always be translated.
-functionlike_macro_includelist = []
+functionlike_macro_includelist = [
+    "P4EST_QUADRANT_LEN",
+    "P4EST_QUADRANT_MASK",
+    "P4EST_LAST_OFFSET",
+    "P8EST_QUADRANT_LEN",
+    "P8EST_QUADRANT_MASK",
+    "P8EST_LAST_OFFSET"
+    # "CINDEX_VERSION_ENCODE",
+]
 
 # if true, the generator prints the following message as comments.
 # "# Skipping MacroDefinition: ..."

--- a/examples/t8_step2_uniform_forest.jl
+++ b/examples/t8_step2_uniform_forest.jl
@@ -71,7 +71,7 @@ end
 #                    partitioned across the processes in \a comm.
 function t8_step2_build_uniform_forest(comm, cmesh, level)
     # /* Create the refinement scheme. */
-    scheme = t8_scheme_new_default()
+    scheme = t8_scheme_new_default_cxx()
     # /* Creat the uniform forest. */
     forest = t8_forest_new_uniform(cmesh, scheme, level, 0, comm)
 
@@ -127,9 +127,9 @@ cmesh = t8_step2_build_prismcube_coarse_mesh(mpicom)
 # Build the uniform forest, it is automatically partitioned among the processes.
 forest = t8_step2_build_uniform_forest(mpicom, cmesh, level)
 # Get the local number of elements.
-local_num_elements = t8_forest_get_local_num_leaf_elements(forest)
+local_num_elements = t8_forest_get_local_num_elements(forest)
 # Get the global number of elements.
-global_num_elements = t8_forest_get_global_num_leaf_elements(forest)
+global_num_elements = t8_forest_get_global_num_elements(forest)
 
 # Print information on the forest.
 t8_global_productionf(" [step2] Created uniform forest.\n")

--- a/examples/t8_step3_adapt_forest.jl
+++ b/examples/t8_step3_adapt_forest.jl
@@ -63,7 +63,7 @@ t8_global_productionf(" [step3] \n")
 # Build a cube cmesh with tet, hex, and prism trees.
 cmesh = t8_cmesh_new_hypercube_hybrid(comm, 0, 0)
 t8_global_productionf(" [step3] Created coarse mesh.\n")
-forest = t8_forest_new_uniform(cmesh, t8_scheme_new_default(), level, 0, comm)
+forest = t8_forest_new_uniform(cmesh, t8_scheme_new_default_cxx(), level, 0, comm)
 
 # Print information of the forest.
 t8_global_productionf(" [step3] Created uniform forest.\n")

--- a/examples/t8_step3_common.jl
+++ b/examples/t8_step3_common.jl
@@ -16,18 +16,17 @@ end
 #   return > 0 -> The first element should get refined.
 #   return = 0 -> The first element should not get refined.
 #   return < 0 -> The whole family should get coarsened.
-#
+#  
 # \param [in] forest       The current forest that is in construction.
 # \param [in] forest_from  The forest from which we adapt the current forest (in our case, the uniform forest)
 # \param [in] which_tree   The process local id of the current tree.
-# \param [in] tree_class   The eclass of \a which_tree.
 # \param [in] lelement_id  The tree local index of the current element (or the first of the family).
-# \param [in] scheme       The refinement scheme for this tree's element class.
-# \param [in] is_family    If 1, the first \a num_elements entries in \a elements form a family. If 0, they do not.
+# \param [in] ts           The refinement scheme for this tree's element class.
+# \param [in] is_family    if 1, the first \a num_elements entries in \a elements form a family. If 0, they do not.
 # \param [in] num_elements The number of entries in \a elements elements that are defined.
 # \param [in] elements     The element or family of elements to consider for refinement/coarsening.
-function t8_step3_adapt_callback(forest, forest_from, which_tree, tree_class, lelement_id,
-                                 scheme, is_family, num_elements, elements_ptr)::Cint
+function t8_step3_adapt_callback(forest, forest_from, which_tree, lelement_id,
+                                 ts, is_family, num_elements, elements_ptr)::Cint
     # Our adaptation criterion is to look at the midpoint coordinates of the current element and if
     # they are inside a sphere around a given midpoint we refine, if they are outside, we coarsen.
 
@@ -97,9 +96,9 @@ function t8_step3_print_forest_information(forest)
     @T8_ASSERT(t8_forest_is_committed(forest)==1)
 
     # Get the local number of elements.
-    local_num_elements = t8_forest_get_local_num_leaf_elements(forest)
+    local_num_elements = t8_forest_get_local_num_elements(forest)
     # Get the global number of elements.
-    global_num_elements = t8_forest_get_global_num_leaf_elements(forest)
+    global_num_elements = t8_forest_get_global_num_elements(forest)
 
     t8_global_productionf(" [step3] Local number of elements:\t\t%i\n", local_num_elements)
     t8_global_productionf(" [step3] Global number of elements:\t%li\n", global_num_elements)

--- a/examples/t8_step4_partition_balance_ghost.jl
+++ b/examples/t8_step4_partition_balance_ghost.jl
@@ -215,7 +215,7 @@ t8_global_productionf(" [step4] \n")
 # Build a cube cmesh with tet, hex, and prism trees.
 cmesh = t8_cmesh_new_hypercube_hybrid(comm, 0, 0)
 t8_global_productionf(" [step4] Created coarse mesh.\n")
-forest = t8_forest_new_uniform(cmesh, t8_scheme_new_default(), level, 0, comm)
+forest = t8_forest_new_uniform(cmesh, t8_scheme_new_default_cxx(), level, 0, comm)
 
 # Print information of the forest.
 t8_step3_print_forest_information(forest);

--- a/examples/t8_step5_element_data.jl
+++ b/examples/t8_step5_element_data.jl
@@ -59,7 +59,7 @@ end
 
 function t8_step5_build_forest(comm, level)
     cmesh = t8_cmesh_new_hypercube_hybrid(comm, 0, 0)
-    scheme = t8_scheme_new_default()
+    scheme = t8_scheme_new_default_cxx()
 
     adapt_data = t8_step3_adapt_data_t((0.5, 0.5, 1.0),      # Midpoints of the sphere.
                                        0.2,                  # Refine if inside this radius.
@@ -88,7 +88,7 @@ function t8_step5_create_element_data(forest)
     @T8_ASSERT(t8_forest_is_committed(forest)==1)
 
     # Get the number of local elements of forest.
-    num_local_elements = t8_forest_get_local_num_leaf_elements(forest)
+    num_local_elements = t8_forest_get_local_num_elements(forest)
     # Get the number of ghost elements of forest.
     num_ghost_elements = t8_forest_get_num_ghosts(forest)
 
@@ -107,18 +107,16 @@ function t8_step5_create_element_data(forest)
 
     # Let us now fill the data with something.  For this, we iterate through all
     # trees and for each tree through all its elements, calling
-    # t8_forest_get_leaf_element_in_tree to get a pointer to the current element.
+    # t8_forest_get_element_in_tree to get a pointer to the current element.
     # This is the recommended and most performant way.  An alternative is to
     # iterate over the number of local elements and use t8_forest_get_element.
     # However, this function needs to perform a binary search for the element and
-    # the tree it is in, while t8_forest_get_leaf_element_in_tree has a constant look
+    # the tree it is in, while t8_forest_get_element_in_tree has a constant look
     # up time. You should only use t8_forest_get_element if you do not know in
     # which tree an element is.
 
     # Get the number of trees that have elements of this process.
     num_local_trees = t8_forest_get_num_local_trees(forest)
-
-    scheme = t8_forest_get_scheme(forest)
 
     current_index = 0
     for itree in 0:(num_local_trees - 1)
@@ -127,9 +125,10 @@ function t8_step5_create_element_data(forest)
         # also a different way to interpret its elements. In order to be able to handle elements
         # of a tree, we need to get its eclass_scheme, and in order to so we first get its eclass.
         tree_class = t8_forest_get_tree_class(forest, itree)
+        eclass_scheme = t8_forest_get_eclass_scheme(forest, tree_class)
 
         # Get the number of elements of this tree.
-        num_elements_in_tree = t8_forest_get_tree_num_leaf_elements(forest, itree)
+        num_elements_in_tree = t8_forest_get_tree_num_elements(forest, itree)
         # This loop iterates through all the local elements of the forest in the current tree.
         for ielement in 0:(num_elements_in_tree - 1)
             current_index += 1 # Note: Julia has 1-based indexing, while C/C++ starts with 0.
@@ -138,11 +137,11 @@ function t8_step5_create_element_data(forest)
             # to store data for this element. */ Since in this example we want to
             # compute the data based on the element in question, we need to get a
             # pointer to this element.
-            element = t8_forest_get_leaf_element_in_tree(forest, itree, ielement)
+            element = t8_forest_get_element_in_tree(forest, itree, ielement)
 
             # We want to store the elements level and its volume as data. We compute these
             # via the eclass_scheme and the forest_element interface.
-            level = t8_element_get_level(scheme, tree_class, element)
+            level = t8_element_level(eclass_scheme, element)
             volume = t8_forest_element_volume(forest, itree, element)
 
             element_data[current_index] = t8_step5_data_per_element_t(level, volume)
@@ -179,7 +178,7 @@ end
 # We support two types: T8_VTK_SCALAR - One double per element
 #                  and  T8_VTK_VECTOR - 3 doubles per element
 function t8_step5_output_data_to_vtu(forest, element_data, prefix)
-    num_elements = t8_forest_get_local_num_leaf_elements(forest)
+    num_elements = t8_forest_get_local_num_elements(forest)
     # We need to allocate a new array to store the volumes on their own.
     # This array has one entry per local element. */
     element_volumes = Vector{Cdouble}(undef, num_elements)
@@ -256,7 +255,7 @@ element_data = t8_step5_create_element_data(forest)
 
 t8_global_productionf(" [step5] Computed level and volume data for local elements.\n")
 
-if t8_forest_get_local_num_leaf_elements(forest) > 0
+if t8_forest_get_local_num_elements(forest) > 0
     # Output the stored data of the first local element (if it exists).
     t8_global_productionf(" [step5] Element 0 has level %i and volume %e.\n",
                           element_data[1].level, element_data[1].volume)
@@ -270,18 +269,16 @@ t8_global_productionf(" [step5] Exchanged ghost data.\n")
 
 if t8_forest_get_num_ghosts(forest) > 0
     # Output the data of the first ghost element (if it exists).
-    first_ghost_index = t8_forest_get_local_num_leaf_elements(forest)
+    first_ghost_index = t8_forest_get_local_num_elements(forest)
     t8_global_productionf(" [step5] Ghost 0 has level %i and volume %e.\n",
                           element_data[first_ghost_index + 1].level,
                           element_data[first_ghost_index + 1].volume)
 end
 
 # Output the volume data to vtu.
-if !(CI_ON_WINDOWS || CI_ON_MACOS)
-    t8_step5_output_data_to_vtu(forest, element_data, prefix_forest_with_data)
-    t8_global_productionf(" [step5] Wrote forest and volume data to %s*.\n",
-                          prefix_forest_with_data)
-end
+t8_step5_output_data_to_vtu(forest, element_data, prefix_forest_with_data)
+t8_global_productionf(" [step5] Wrote forest and volume data to %s*.\n",
+                      prefix_forest_with_data)
 
 #
 # Clean-up.

--- a/examples/t8_step6_stencil.jl
+++ b/examples/t8_step6_stencil.jl
@@ -78,7 +78,7 @@ end
 function t8_step6_build_forest(comm, dim, level)
     cmesh = t8_cmesh_new_periodic(comm, dim)
 
-    scheme = t8_scheme_new_default()
+    scheme = t8_scheme_new_default_cxx()
 
     adapt_data = t8_step3_adapt_data_t((0.0, 0.0, 0.0),      # Midpoints of the sphere.
                                        0.5,                  # Refine if inside this radius.
@@ -111,7 +111,7 @@ function t8_step6_create_element_data(forest)
     @T8_ASSERT(t8_forest_is_committed(forest)==1)
 
     # Get the number of local elements of forest.
-    num_local_elements = t8_forest_get_local_num_leaf_elements(forest)
+    num_local_elements = t8_forest_get_local_num_elements(forest)
     # Get the number of ghost elements of forest.
     num_ghost_elements = t8_forest_get_num_ghosts(forest)
 
@@ -130,33 +130,32 @@ function t8_step6_create_element_data(forest)
     # Element Midpoint
     midpoint = Vector{Cdouble}(undef, 3)
 
-    scheme = t8_forest_get_scheme(forest)
-
     # Loop over all local trees in the forest.
     current_index = 0
     for itree in 0:(num_local_trees - 1)
         tree_class = t8_forest_get_tree_class(forest, itree)
+        eclass_scheme = t8_forest_get_eclass_scheme(forest, tree_class)
 
         # Get the number of elements of this tree.
-        num_elements_in_tree = t8_forest_get_tree_num_leaf_elements(forest, itree)
+        num_elements_in_tree = t8_forest_get_tree_num_elements(forest, itree)
 
         # Loop over all local elements in the tree.
         for ielement in 0:(num_elements_in_tree - 1)
             current_index += 1 # Note: Julia has 1-based indexing, while C/C++ starts with 0.
 
-            element = t8_forest_get_leaf_element_in_tree(forest, itree, ielement)
+            element = t8_forest_get_element_in_tree(forest, itree, ielement)
 
-            level = t8_element_get_level(scheme, tree_class, element)
+            level = t8_element_level(eclass_scheme, element)
             volume = t8_forest_element_volume(forest, itree, element)
 
             t8_forest_element_centroid(forest, itree, element, pointer(midpoint))
 
-            t8_element_get_vertex_reference_coords(scheme, tree_class, element, 0,
-                                                   @view(verts[:, 1]))
-            t8_element_get_vertex_reference_coords(scheme, tree_class, element, 1,
-                                                   @view(verts[:, 2]))
-            t8_element_get_vertex_reference_coords(scheme, tree_class, element, 2,
-                                                   @view(verts[:, 3]))
+            t8_element_vertex_reference_coords(eclass_scheme, element, 0,
+                                               @view(verts[:, 1]))
+            t8_element_vertex_reference_coords(eclass_scheme, element, 1,
+                                               @view(verts[:, 2]))
+            t8_element_vertex_reference_coords(eclass_scheme, element, 2,
+                                               @view(verts[:, 3]))
 
             dx = verts[1, 2] - verts[1, 1]
             dy = verts[2, 3] - verts[2, 1]
@@ -191,21 +190,21 @@ function t8_step6_compute_stencil(forest, element_data)
     dx = Vector{Cdouble}(undef, 3)
     dy = Vector{Cdouble}(undef, 3)
 
-    scheme = t8_forest_get_scheme(forest)
-
     # Loop over all local trees in the forest. For each local tree the element
     # data (level, midpoint[3], dx, dy, volume, height, schlieren, curvature) of
     # each element is calculated and stored into the element data array.
     current_index = 0
     for itree in 0:(num_local_trees - 1)
         tree_class = t8_forest_get_tree_class(forest, itree)
-        num_elements_in_tree = t8_forest_get_tree_num_leaf_elements(forest, itree)
+        eclass_scheme = t8_forest_get_eclass_scheme(forest, tree_class)
+
+        num_elements_in_tree = t8_forest_get_tree_num_elements(forest, itree)
 
         # Loop over all local elements in the tree.
         for ielement in 0:(num_elements_in_tree - 1)
             current_index += 1 # Note: Julia has 1-based indexing, while C/C++ starts with 0.
 
-            element = t8_forest_get_leaf_element_in_tree(forest, itree, ielement)
+            element = t8_forest_get_element_in_tree(forest, itree, ielement)
 
             # Gather center point of the 3x3 stencil.
             stencil[2, 2] = element_data[current_index].height
@@ -213,16 +212,17 @@ function t8_step6_compute_stencil(forest, element_data)
             dy[2] = element_data[current_index].dy
 
             # Loop over all faces of an element.
-            num_faces = t8_element_get_num_faces(scheme, tree_class, element)
+            num_faces = t8_element_num_faces(eclass_scheme, element)
             for iface in 1:num_faces
                 neighids_ref = Ref{Ptr{t8_locidx_t}}()
                 neighbors_ref = Ref{Ptr{Ptr{t8_element}}}()
-                neigh_scheme_ref = Ref{t8_eclass_t}()
+                neigh_scheme_ref = Ref{Ptr{t8_eclass_scheme}}()
 
                 dual_faces_ref = Ref{Ptr{Cint}}()
                 num_neighbors_ref = Ref{Cint}()
 
                 forest_is_balanced = Cint(1)
+
                 t8_forest_leaf_face_neighbors(forest, itree, element,
                                               neighbors_ref, iface - 1, dual_faces_ref,
                                               num_neighbors_ref,
@@ -404,10 +404,8 @@ t8_step6_exchange_ghost_data(forest, element_data)
 t8_step6_compute_stencil(forest, element_data)
 
 # Output the data to vtu files.
-if !(CI_ON_WINDOWS || CI_ON_MACOS)
-    t8_step6_output_data_to_vtu(forest, element_data, prefix_forest_with_data)
-    t8_global_productionf(" Wrote forest and data to %s*.\n", prefix_forest_with_data)
-end
+t8_step6_output_data_to_vtu(forest, element_data, prefix_forest_with_data)
+t8_global_productionf(" Wrote forest and data to %s*.\n", prefix_forest_with_data)
 
 #
 # Clean-up

--- a/src/Libt8.jl
+++ b/src/Libt8.jl
@@ -1,6 +1,6 @@
 module Libt8
 
-using CEnum: CEnum, @cenum
+using CEnum: @cenum
 
 to_c_type(t::Type) = t
 to_c_type_pairs(va_list) = map(enumerate(to_c_type.(va_list))) do (ind, type)
@@ -66,34 +66,6 @@ const INT32_MAX = typemax(Cint)
 const INT64_MIN = typemin(Clonglong)
 const INT64_MAX = typemax(Clonglong)
 
-
-"""
-    sc_extern_c_hack_1()
-
-We want to export the whole implementation to be callable from "C".
-
-### Prototype
-```c
-SC_EXTERN_C_BEGIN;
-```
-"""
-function sc_extern_c_hack_1()
-    @ccall libsc.sc_extern_c_hack_1()::Cvoid
-end
-
-"""
-    sc_extern_c_hack_2()
-
-` `
-
-### Prototype
-```c
-SC_EXTERN_C_END;
-```
-"""
-function sc_extern_c_hack_2()
-    @ccall libsc.sc_extern_c_hack_2()::Cvoid
-end
 
 """
     sc_abort_verbose(filename, lineno, msg)
@@ -181,8 +153,8 @@ The central log function to be called by all packages. Dispatches the log calls 
 
 # Arguments
 * `package`:\\[in\\] Must be a registered package id or -1.
-* `category`:\\[in\\] Must be [`SC_LC_NORMAL`](@ref) or [`SC_LC_GLOBAL`](@ref).
-* `priority`:\\[in\\] Must be > [`SC_LP_ALWAYS`](@ref) and < [`SC_LP_SILENT`](@ref).
+* `category`:\\[in\\] Must be `SC_LC_NORMAL` or `SC_LC_GLOBAL`.
+* `priority`:\\[in\\] Must be > `SC_LP_ALWAYS` and < `SC_LP_SILENT`.
 ### Prototype
 ```c
 void sc_log (const char *filename, int lineno, int package, int category, int priority, const char *msg);
@@ -213,7 +185,7 @@ struct sc_array
     elem_size::Csize_t
     elem_count::Csize_t
     byte_alloc::Cssize_t
-    array::Cstring
+    array::Ptr{Int8}
 end
 
 """The [`sc_array`](@ref) object provides a dynamic array of equal-size elements. Elements are accessed by their 0-based index. Their address may change. The number of elements (== elem\\_count) of the array can be changed by sc_array_resize and sc_array_rewind. Elements can be sorted with sc_array_sort. If the array is sorted, it can be searched with sc_array_bsearch. A priority queue is implemented with pqueue\\_add and pqueue\\_pop (untested)."""
@@ -421,7 +393,7 @@ size_t sc_mpi_sizeof (sc_MPI_Datatype t);
 ```
 """
 function sc_mpi_sizeof(t)
-    @ccall libsc.sc_mpi_sizeof(t::Cint)::Csize_t
+    @ccall libsc.sc_mpi_sizeof(t::MPI_Datatype)::Csize_t
 end
 
 """
@@ -610,9 +582,9 @@ end
 Controls the default SC log behavior.
 
 # Arguments
-* `log_stream`:\\[in\\] Set stream to use by [`sc_logf`](@ref) (or NULL for stdout).
+* `log_stream`:\\[in\\] Set stream to use by `sc_logf` (or NULL for stdout).
 * `log_handler`:\\[in\\] Set default SC log handler (NULL selects builtin).
-* `log_threshold`:\\[in\\] Set default SC log threshold (or [`SC_LP_DEFAULT`](@ref)). May be [`SC_LP_ALWAYS`](@ref) or [`SC_LP_SILENT`](@ref).
+* `log_threshold`:\\[in\\] Set default SC log threshold (or `SC_LP_DEFAULT`). May be `SC_LP_ALWAYS` or `SC_LP_SILENT`.
 ### Prototype
 ```c
 void sc_set_log_defaults (FILE * log_stream, sc_log_handler_t log_handler, int log_threshold);
@@ -791,7 +763,7 @@ end
 """
     sc_package_set_verbosity(package_id, log_priority)
 
-Set the logging verbosity of a registered package. This can be called at any point in the program, any number of times. It can only lower the verbosity at and below the value of [`SC_LP_THRESHOLD`](@ref).
+Set the logging verbosity of a registered package. This can be called at any point in the program, any number of times. It can only lower the verbosity at and below the value of `SC_LP_THRESHOLD`.
 
 # Arguments
 * `package_id`:\\[in\\] Must be a registered package identifier.
@@ -838,7 +810,7 @@ end
 """
     sc_package_print_summary(log_priority)
 
-Print a summary of all packages registered with SC. Uses the [`SC_LC_GLOBAL`](@ref) log category which by default only prints on rank 0.
+Print a summary of all packages registered with SC. Uses the `SC_LC_GLOBAL` log category which by default only prints on rank 0.
 
 # Arguments
 * `log_priority`:\\[in\\] Priority passed to sc log functions.
@@ -936,7 +908,7 @@ end
 """
     sc_is_root()
 
-Identify the root process. Only meaningful between [`sc_init`](@ref) and [`sc_finalize`](@ref) and with a communicator that is not [`sc_MPI_COMM_NULL`](@ref) (otherwise always true).
+Identify the root process. Only meaningful between [`sc_init`](@ref) and [`sc_finalize`](@ref) and with a communicator that is not `sc_MPI_COMM_NULL` (otherwise always true).
 
 # Returns
 Return true for the root process and false otherwise.
@@ -2897,9 +2869,6 @@ function sc_recycle_array_remove(rec_array, position)
     @ccall libsc.sc_recycle_array_remove(rec_array::Ptr{sc_recycle_array_t}, position::Csize_t)::Ptr{Cvoid}
 end
 
-"""A type for holding process ids."""
-const t8_procidx_t = Cint
-
 """A type for storing SFC indices"""
 const t8_linearidx_t = UInt64
 
@@ -2908,18 +2877,13 @@ const t8_linearidx_t = UInt64
 
 Communication tags used internal to t8code.
 
-| Enumerator                                  | Note                                                     |
-| :------------------------------------------ | :------------------------------------------------------- |
-| T8\\_MPI\\_TAG\\_FIRST                      | Dummy first MPT tag.                                     |
-| T8\\_MPI\\_PARTITION\\_CMESH                | Used for coarse mesh partitioning                        |
-| T8\\_MPI\\_PARTITION\\_FOREST               | Used for forest partitioning                             |
-| T8\\_MPI\\_GHOST\\_FOREST                   | Used for for ghost layer creation                        |
-| T8\\_MPI\\_GHOST\\_EXC\\_FOREST             | Used for ghost data exchange                             |
-| T8\\_MPI\\_CMESH\\_UNIFORM\\_BOUNDS\\_START | Used for cmesh uniform bounds computation.               |
-| T8\\_MPI\\_CMESH\\_UNIFORM\\_BOUNDS\\_END   |                                                          |
-| T8\\_MPI\\_TEST\\_ELEMENT\\_PACK\\_TAG      | Used for testing mpi pack and unpack functionality       |
-| T8\\_MPI\\_PFC\\_TAG                        | Used for data exchange during partition for coarsening.  |
-| T8\\_MPI\\_TAG\\_LAST                       | Dummy last MPI tag.                                      |
+| Enumerator                             | Note                                                |
+| :------------------------------------- | :-------------------------------------------------- |
+| T8\\_MPI\\_PARTITION\\_CMESH           | Used for coarse mesh partitioning                   |
+| T8\\_MPI\\_PARTITION\\_FOREST          | Used for forest partitioning                        |
+| T8\\_MPI\\_GHOST\\_FOREST              | Used for for ghost layer creation                   |
+| T8\\_MPI\\_GHOST\\_EXC\\_FOREST        | Used for ghost data exchange                        |
+| T8\\_MPI\\_TEST\\_ELEMENT\\_PACK\\_TAG | Used for testing mpi pack and unpack functionality  |
 """
 @cenum t8_MPI_tag_t::UInt32 begin
     T8_MPI_TAG_FIRST = 214
@@ -2927,11 +2891,8 @@ Communication tags used internal to t8code.
     T8_MPI_PARTITION_FOREST = 296
     T8_MPI_GHOST_FOREST = 297
     T8_MPI_GHOST_EXC_FOREST = 298
-    T8_MPI_CMESH_UNIFORM_BOUNDS_START = 299
-    T8_MPI_CMESH_UNIFORM_BOUNDS_END = 300
-    T8_MPI_TEST_ELEMENT_PACK_TAG = 301
-    T8_MPI_PFC_TAG = 302
-    T8_MPI_TAG_LAST = 303
+    T8_MPI_TEST_ELEMENT_PACK_TAG = 299
+    T8_MPI_TAG_LAST = 300
 end
 
 # automatic type deduction for variadic arguments may not be what you want, please use with caution
@@ -3008,28 +2969,12 @@ end
     end
 
 """
-    t8_set_external_log_fcn(log_fcn)
-
-Set a custom logging function to be used by t8code. When setting a custom logging function, the t8code internal logging function will be ignored.
-
-# Arguments
-* `log_fcn`:\\[in\\] A function pointer to a logging function
-### Prototype
-```c
-void t8_set_external_log_fcn (void (*log_fcn) (int category, int priority, const char *msg));
-```
-"""
-function t8_set_external_log_fcn(log_fcn)
-    @ccall libt8.t8_set_external_log_fcn(log_fcn::Ptr{Cvoid})::Cvoid
-end
-
-"""
     t8_init(log_threshold)
 
 Register t8code with libsc and print version and variable information.
 
 # Arguments
-* `log_threshold`:\\[in\\] Declared in sc.h. [`SC_LP_DEFAULT`](@ref) is fine. You can also choose from log levels SC\\_LP\\_*.
+* `log_threshold`:\\[in\\] Declared in sc.h. `SC_LP_DEFAULT` is fine. You can also choose from log levels SC\\_LP\\_*.
 ### Prototype
 ```c
 void t8_init (int log_threshold);
@@ -3040,22 +2985,21 @@ function t8_init(log_threshold)
 end
 
 """
-    t8_sc_array_index_locidx(array, index)
+    t8_sc_array_index_locidx(array, it)
 
 Return a pointer to an array element indexed by a [`t8_locidx_t`](@ref).
 
 # Arguments
-* `array`:\\[in\\] The array of elements.
 * `index`:\\[in\\] needs to be in [0]..[elem\\_count-1].
 # Returns
-A void * pointing to entry *index* in *array*.
+A void * pointing to entry *it* in *array*.
 ### Prototype
 ```c
-void * t8_sc_array_index_locidx (const sc_array_t *array, const t8_locidx_t index);
+void * t8_sc_array_index_locidx (const sc_array_t *array, const t8_locidx_t it);
 ```
 """
-function t8_sc_array_index_locidx(array, index)
-    @ccall libt8.t8_sc_array_index_locidx(array::Ptr{sc_array_t}, index::t8_locidx_t)::Ptr{Cvoid}
+function t8_sc_array_index_locidx(array, it)
+    @ccall libt8.t8_sc_array_index_locidx(array::Ptr{sc_array_t}, it::t8_locidx_t)::Ptr{Cvoid}
 end
 
 """
@@ -3162,11 +3106,6 @@ void sc_shmem_prefix (void *sendbuf, void *recvbuf, int count, sc_MPI_Datatype t
 function sc_shmem_prefix(sendbuf, recvbuf, count, type, op, comm)
     @ccall libsc.sc_shmem_prefix(sendbuf::Ptr{Cvoid}, recvbuf::Ptr{Cvoid}, count::Cint, type::Cint, op::Cint, comm::MPI_Comm)::Cvoid
 end
-
-mutable struct t8_cmesh end
-
-"""Forward pointer reference to hidden cmesh implementation. This reference needs to be known by [`t8_geometry`](@ref), hence we  put it before the include."""
-const t8_cmesh_t = Ptr{t8_cmesh}
 
 """
     sc_refcount
@@ -3326,14 +3265,254 @@ function sc_refcount_is_last(rc)
     @ccall libsc.sc_refcount_is_last(rc::Ptr{sc_refcount_t})::Cint
 end
 
-mutable struct t8_ctree end
+mutable struct t8_eclass_scheme end
 
-"""Forward pointer references to hidden implementations of tree."""
+"""This typedef holds virtual functions for a particular element class."""
+const t8_eclass_scheme_c = t8_eclass_scheme
+
+"""
+    t8_scheme_cxx
+
+The scheme holds implementations for one or more element classes.
+
+| Field            | Note                                                   |
+| :--------------- | :----------------------------------------------------- |
+| rc               | Reference counter for this scheme.                     |
+| eclass\\_schemes | This array holds one virtual table per element class.  |
+"""
+struct t8_scheme_cxx
+    rc::sc_refcount_t
+    eclass_schemes::NTuple{8, Ptr{t8_eclass_scheme_c}}
+end
+
+"""The scheme holds implementations for one or more element classes."""
+const t8_scheme_cxx_t = t8_scheme_cxx
+
+"""We can reuse the reference counter type from libsc."""
+const t8_refcount_t = sc_refcount_t
+
+struct t8_cmesh_trees
+    from_proc::Ptr{sc_array_t}
+    tree_to_proc::Ptr{Cint}
+    ghost_to_proc::Ptr{Cint}
+    ghost_globalid_to_local_id::Ptr{sc_hash_t}
+    global_local_mempool::Ptr{sc_mempool_t}
+end
+
+const t8_cmesh_trees_t = Ptr{t8_cmesh_trees}
+
+mutable struct t8_shmem_array end
+
+const t8_shmem_array_t = Ptr{t8_shmem_array}
+
+mutable struct t8_geometry_handler end
+
+"""This typedef holds virtual functions for the geometry handler. We need it so that we can use [`t8_geometry_handler_c`](@ref) pointers in .c files without them seeing the actual C++ code (and then not compiling) TODO: Delete this when the cmesh is a proper cpp class."""
+const t8_geometry_handler_c = t8_geometry_handler
+
+"""
+    t8_stash
+
+The stash data structure is used to store information about the cmesh before it is committed. In particular we store the eclasses of the trees, the face-connections and the tree attributes. Using the stash structure allows us to have a very flexible interface. When constructing a new mesh, the user can specify all these mesh entities in arbitrary order. As soon as the cmesh is committed the information is copied from the stash to the cmesh in an order mannered.
+
+| Field      | Note                                                                    |
+| :--------- | :---------------------------------------------------------------------- |
+| classes    | Stores the eclasses of the trees.  # See also [`t8_stash_class`](@ref)  |
+| joinfaces  | Stores the face-connections.  # See also [`t8_stash_joinface`](@ref)    |
+| attributes | Stores the attributes.  # See also [`t8_stash_attribute`](@ref)         |
+"""
+struct t8_stash
+    classes::sc_array_t
+    joinfaces::sc_array_t
+    attributes::sc_array_t
+end
+
+const t8_stash_t = Ptr{t8_stash}
+
+"""
+    t8_cprofile
+
+This struct is used to profile cmesh algorithms. The cmesh struct stores a pointer to a profile struct, and if it is nonzero, various runtimes and data measurements are stored here.
+
+| Field                             | Note                                                                                                          |
+| :-------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| partition\\_trees\\_shipped       | The number of trees this process has sent to other in the last partition call.                                |
+| partition\\_ghosts\\_shipped      | The number of ghosts this process has sent to other in the last partition call.                               |
+| partition\\_trees\\_recv          | The number of trees this process has received from other in the last partition call.                          |
+| partition\\_ghosts\\_recv         | The number of ghosts this process has received from other in the last partition call.                         |
+| partition\\_bytes\\_sent          | The total number of bytes sent to other processes in the last partition call.                                 |
+| partition\\_procs\\_sent          | The number of different processes this process has send local trees or ghosts to in the last partition call.  |
+| first\\_tree\\_shared             | 1 if this processes' first tree is shared. 0 if not.                                                          |
+| partition\\_runtime               | The runtime of the last call to [`t8_cmesh_partition`](@ref).                                                 |
+| commit\\_runtime                  | The runtime of the last call to [`t8_cmesh_commit`](@ref).                                                    |
+| geometry\\_evaluate\\_num\\_calls | The number of calls to [`t8_geometry_evaluate`](@ref).                                                        |
+| geometry\\_evaluate\\_runtime     | The accumulated runtime of calls to [`t8_geometry_evaluate`](@ref).                                           |
+# See also
+[`t8_cmesh_set_profiling`](@ref) and, [`t8_cmesh_print_profile`](@ref)
+"""
+struct t8_cprofile
+    partition_trees_shipped::t8_locidx_t
+    partition_ghosts_shipped::t8_locidx_t
+    partition_trees_recv::t8_locidx_t
+    partition_ghosts_recv::t8_locidx_t
+    partition_bytes_sent::Csize_t
+    partition_procs_sent::Cint
+    first_tree_shared::Cint
+    partition_runtime::Cdouble
+    commit_runtime::Cdouble
+    geometry_evaluate_num_calls::Cdouble
+    geometry_evaluate_runtime::Cdouble
+end
+
+"""
+This struct is used to profile cmesh algorithms. The cmesh struct stores a pointer to a profile struct, and if it is nonzero, various runtimes and data measurements are stored here.
+
+# See also
+[`t8_cmesh_set_profiling`](@ref) and, [`t8_cmesh_print_profile`](@ref)
+"""
+const t8_cprofile_t = t8_cprofile
+
+"""
+    t8_cmesh
+
+This structure holds the connectivity data of the coarse mesh. It can either be replicated, then each process stores a copy of the whole mesh, or partitioned. In the latter case, each process only stores a local portion of the mesh plus information about ghost elements.
+
+The coarse mesh is a collection of coarse trees that can be identified along faces. TODO: this description is outdated. rewrite it. The array ctrees stores these coarse trees sorted by their (global) tree\\_id. If the mesh if partitioned it is partitioned according to an (possible only virtually existing) underlying fine mesh. Therefore the ctrees array can store duplicated trees on different processes, if each of these processes owns elements of the same tree in the fine mesh.
+
+Each tree stores information about its face-neighbours in an array of t8_ctree_fneighbor.
+
+If partitioned the ghost trees are stored in a hash table that is backed up by an array. The hash value of a ghost tree is its tree\\_id modulo the number of ghosts on this process.
+
+| Field                              | Note                                                                                                                                                                                                               |
+| :--------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| committed                          | Flag that specifies whether the cmesh is committed or not. t8_cmesh_commit                                                                                                                                         |
+| dimension                          | The dimension of the cmesh. It is set when the first tree is inserted.                                                                                                                                             |
+| set\\_partition                    | If nonzero the cmesh is partitioned. If zero each process has the whole cmesh.                                                                                                                                     |
+| face\\_knowledge                   | If partitioned the level of face knowledge that is expected. t8_mesh_set_partitioned; see t8_cmesh_set_partition.                                                                                                  |
+| set\\_partition\\_scheme           | If the cmesh is to be partitioned according to a uniform level, the scheme that describes the refinement pattern. See t8_cmesh_set_partition.                                                                      |
+| set\\_partition\\_level            | Non-negative if the cmesh should be partitioned from an already existing cmesh with an assumed *level* uniform mesh underneath.                                                                                    |
+| set\\_from                         | If this cmesh shall be derived from an existing cmesh by copy or more elaborate modification, we store a pointer to this other cmesh here.                                                                         |
+| mpirank                            | Number of this MPI process.                                                                                                                                                                                        |
+| mpisize                            | Number of MPI processes.                                                                                                                                                                                           |
+| rc                                 | The reference count of the cmesh.                                                                                                                                                                                  |
+| num\\_trees                        | The global number of trees                                                                                                                                                                                         |
+| num\\_local\\_trees                | If partitioned the number of trees on this process.  Otherwise the global number of trees.                                                                                                                         |
+| num\\_ghosts                       | If partitioned the number of neighbor trees owned by different processes.                                                                                                                                          |
+| num\\_local\\_trees\\_per\\_eclass | After commit the number of local trees for each eclass. Stores the same entries as *num_trees_per_eclass*, if the cmesh is replicated.                                                                             |
+| num\\_trees\\_per\\_eclass         | After commit the number of global trees for each eclass.                                                                                                                                                           |
+| trees                              | structure that holds all local trees and ghosts                                                                                                                                                                    |
+| first\\_tree                       | The global index of the first local tree on this process.  Zero if the cmesh is not partitioned. -1 if this processor is empty. See also https://github.com/DLR-AMR/t8code/wiki/Tree-indexing                      |
+| first\\_tree\\_shared              | If partitioned true if the first tree on this process is also the last tree  on the next process. Always zero if num\\_local\\_trees = 0                                                                           |
+| tree\\_offsets                     | If partitioned for each process the global index of its first local tree or -(first local tree) - 1 if the first tree on that process is shared. Since this is very memory consuming we only fill it when needed.  |
+| geometry\\_handler                 | Handles all geometries that are used by trees in this cmesh.                                                                                                                                                       |
+| stash                              | Used as temporary storage for the trees before commit.                                                                                                                                                             |
+| profile                            | Used to measure runtimes and statistics of the cmesh algorithms.                                                                                                                                                   |
+# See also
+t8\\_ctree\\_fneighbor
+"""
+struct t8_cmesh
+    committed::Cint
+    dimension::Cint
+    set_partition::Cint
+    face_knowledge::Cint
+    set_partition_scheme::Ptr{t8_scheme_cxx_t}
+    set_partition_level::Int8
+    set_from::Ptr{t8_cmesh}
+    mpirank::Cint
+    mpisize::Cint
+    rc::t8_refcount_t
+    num_trees::t8_gloidx_t
+    num_local_trees::t8_locidx_t
+    num_ghosts::t8_locidx_t
+    num_local_trees_per_eclass::NTuple{8, t8_locidx_t}
+    num_trees_per_eclass::NTuple{8, t8_gloidx_t}
+    trees::t8_cmesh_trees_t
+    first_tree::t8_gloidx_t
+    first_tree_shared::Int8
+    tree_offsets::t8_shmem_array_t
+    geometry_handler::Ptr{t8_geometry_handler_c}
+    stash::t8_stash_t
+    profile::Ptr{t8_cprofile_t}
+end
+
+const t8_cmesh_t = Ptr{t8_cmesh}
+
+"""
+    t8_eclass
+
+This enumeration contains all possible element classes.
+
+| Enumerator             | Note                                                                                                               |
+| :--------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| T8\\_ECLASS\\_VERTEX   | The vertex is the only zero-dimensional element class.                                                             |
+| T8\\_ECLASS\\_LINE     | The line is the only one-dimensional element class.                                                                |
+| T8\\_ECLASS\\_QUAD     | The quadrilateral is one of two element classes in two dimensions.                                                 |
+| T8\\_ECLASS\\_TRIANGLE | The element class for a triangle.                                                                                  |
+| T8\\_ECLASS\\_HEX      | The hexahedron is one three-dimensional element class.                                                             |
+| T8\\_ECLASS\\_TET      | The tetrahedron is another three-dimensional element class.                                                        |
+| T8\\_ECLASS\\_PRISM    | The prism has five sides: two opposing triangles joined by three quadrilaterals.                                   |
+| T8\\_ECLASS\\_PYRAMID  | The pyramid has a quadrilateral as base and four triangles as sides.                                               |
+| T8\\_ECLASS\\_COUNT    | This is no element class but can be used as the number of element classes.                                         |
+| T8\\_ECLASS\\_INVALID  | This is no element class but can be used for the case a class of a third party library is not supported by t8code  |
+"""
+@cenum t8_eclass::UInt32 begin
+    T8_ECLASS_ZERO = 0
+    T8_ECLASS_VERTEX = 0
+    T8_ECLASS_LINE = 1
+    T8_ECLASS_QUAD = 2
+    T8_ECLASS_TRIANGLE = 3
+    T8_ECLASS_HEX = 4
+    T8_ECLASS_TET = 5
+    T8_ECLASS_PRISM = 6
+    T8_ECLASS_PYRAMID = 7
+    T8_ECLASS_COUNT = 8
+    T8_ECLASS_INVALID = 9
+end
+
+"""This enumeration contains all possible element classes."""
+const t8_eclass_t = t8_eclass
+
+"""
+    t8_ctree
+
+This structure holds the data of a local tree including the information about face neighbors. For those the tree\\_to\\_face index is computed as follows. Let F be the maximal number of faces of any eclass of the cmesh's dimension, then ttf % F is the face number and ttf / F is the orientation. (t8_eclass_max_num_faces) The orientation is determined as follows. Let my\\_face and other\\_face be the two face numbers of the connecting trees. We chose a main\\_face from them as follows: Either both trees have the same element class, then the face with the lower face number is the main\\_face or the trees belong to different classes in which case the face belonging to the tree with the lower class according to the ordering triangle < square, hex < tet < prism < pyramid, is the main\\_face. Then face corner 0 of the main\\_face connects to a face corner k in the other face. The face orientation is defined as the number k. If the classes are equal and my\\_face == other\\_face, treating either of both faces as the main\\_face leads to the same result. See https://arxiv.org/pdf/1611.02929.pdf for more details.
+
+| Field            | Note                                                                                        |
+| :--------------- | :------------------------------------------------------------------------------------------ |
+| treeid           | The local number of this tree.                                                              |
+| eclass           | The eclass of this tree.                                                                    |
+| neigh\\_offset   | Adding this offset to the address of the tree yields the array of face\\_neighbor entries   |
+| att\\_offset     | Adding this offset to the address of the tree yields the array of attribute\\_info entries  |
+| num\\_attributes | The number of attributes at this tree                                                       |
+"""
+struct t8_ctree
+    treeid::t8_locidx_t
+    eclass::t8_eclass_t
+    neigh_offset::Csize_t
+    att_offset::Csize_t
+    num_attributes::Cint
+end
+
 const t8_ctree_t = Ptr{t8_ctree}
 
-mutable struct t8_cghost end
+"""
+    t8_cghost
 
-"""Forward pointer references to hidden implementations of ghost tree."""
+| Field            | Note                                                                                         |
+| :--------------- | :------------------------------------------------------------------------------------------- |
+| treeid           | The global number of this ghost.                                                             |
+| eclass           | The eclass of this ghost.                                                                    |
+| att\\_offset     | Adding this offset to the address of the ghost yields the array of attribute\\_info entries  |
+| num\\_attributes | The number of attributes at this ghost                                                       |
+"""
+struct t8_cghost
+    treeid::t8_gloidx_t
+    eclass::t8_eclass_t
+    neigh_offset::Csize_t
+    att_offset::Csize_t
+    num_attributes::Cint
+end
+
 const t8_cghost_t = Ptr{t8_cghost}
 
 """
@@ -3352,7 +3531,7 @@ function t8_cmesh_init(pcmesh)
     @ccall libt8.t8_cmesh_init(pcmesh::Ptr{t8_cmesh_t})::Cvoid
 end
 
-# no prototype is found for this function at t8_cmesh.h:79:1, please use with caution
+# no prototype is found for this function at t8_cmesh.h:76:1, please use with caution
 """
     t8_cmesh_new()
 
@@ -3406,19 +3585,23 @@ function t8_cmesh_is_committed(cmesh)
 end
 
 """
-    t8_cmesh_disable_negative_volume_check(cmesh)
+    t8_cmesh_tree_vertices_negative_volume(eclass, vertices, num_vertices)
 
-Disable the debug check for negative volumes in trees during t8_cmesh_commit. Does nothing outside of debug mode.
+Given a set of vertex coordinates for a tree of a given eclass. Query whether the geometric volume of the tree with this coordinates would be negative.
 
 # Arguments
-* `cmesh`:\\[in,out\\]
+* `eclass`:\\[in\\] The eclass of a tree.
+* `vertices`:\\[in\\] The coordinates of the tree's vertices.
+* `num_vertices`:\\[in\\] The number of vertices. *vertices* must hold 3 * *num_vertices* many doubles. *num_vertices* must match t8_eclass_num_vertices[*eclass*]
+# Returns
+True if the geometric volume describe by *vertices* is negative. False otherwise. Returns true if a tree of the given eclass with the given vertex coordinates does have negative volume.
 ### Prototype
 ```c
-void t8_cmesh_disable_negative_volume_check (t8_cmesh_t cmesh);
+int t8_cmesh_tree_vertices_negative_volume (const t8_eclass_t eclass, const double *vertices, const int num_vertices);
 ```
 """
-function t8_cmesh_disable_negative_volume_check(cmesh)
-    @ccall libt8.t8_cmesh_disable_negative_volume_check(cmesh::t8_cmesh_t)::Cvoid
+function t8_cmesh_tree_vertices_negative_volume(eclass, vertices, num_vertices)
+    @ccall libt8.t8_cmesh_tree_vertices_negative_volume(eclass::t8_eclass_t, vertices::Ptr{Cdouble}, num_vertices::Cint)::Cint
 end
 
 """
@@ -3437,10 +3620,6 @@ void t8_cmesh_set_derive (t8_cmesh_t cmesh, t8_cmesh_t set_from);
 function t8_cmesh_set_derive(cmesh, set_from)
     @ccall libt8.t8_cmesh_set_derive(cmesh::t8_cmesh_t, set_from::t8_cmesh_t)::Cvoid
 end
-
-mutable struct t8_shmem_array end
-
-const t8_shmem_array_t = Ptr{t8_shmem_array}
 
 """
     t8_cmesh_alloc_offsets(mpisize, comm)
@@ -3497,27 +3676,22 @@ function t8_cmesh_set_partition_offsets(cmesh, tree_offsets)
     @ccall libt8.t8_cmesh_set_partition_offsets(cmesh::t8_cmesh_t, tree_offsets::t8_shmem_array_t)::Cvoid
 end
 
-mutable struct t8_scheme end
-
-"""The scheme holds implementations for one or more element classes. Opaque pointer for C interface. Detailed documentation at t8_scheme."""
-const t8_scheme_c = t8_scheme
-
 """
-    t8_cmesh_set_partition_uniform(cmesh, element_level, scheme)
+    t8_cmesh_set_partition_uniform(cmesh, element_level, ts)
 
 Declare if a derived cmesh should be partitioned according to a uniform refinement of a given level for the provided scheme. This call is only valid when the cmesh is not yet committed via a call to t8_cmesh_commit and when the cmesh will be derived.
 
 # Arguments
 * `cmesh`:\\[in,out\\] The cmesh to be updated.
 * `element_level`:\\[in\\] The refinement\\_level.
-* `scheme`:\\[in\\] The element scheme describing the refinement pattern. We take ownership. This can be prevented by referencing **scheme** before calling this function.
+* `ts`:\\[in\\] The element scheme describing the refinement pattern. We take ownership. This can be prevented by referencing **ts** before calling this function.
 ### Prototype
 ```c
-void t8_cmesh_set_partition_uniform (t8_cmesh_t cmesh, const int element_level, const t8_scheme_c *scheme);
+void t8_cmesh_set_partition_uniform (t8_cmesh_t cmesh, int element_level, t8_scheme_cxx_t *ts);
 ```
 """
-function t8_cmesh_set_partition_uniform(cmesh, element_level, scheme)
-    @ccall libt8.t8_cmesh_set_partition_uniform(cmesh::t8_cmesh_t, element_level::Cint, scheme::Ptr{t8_scheme_c})::Cvoid
+function t8_cmesh_set_partition_uniform(cmesh, element_level, ts)
+    @ccall libt8.t8_cmesh_set_partition_uniform(cmesh::t8_cmesh_t, element_level::Cint, ts::Ptr{t8_scheme_cxx_t})::Cvoid
 end
 
 """
@@ -3527,11 +3701,11 @@ Refine the cmesh to a given level. Thus split each tree into x^level subtrees TO
 
 ### Prototype
 ```c
-void t8_cmesh_set_refine (t8_cmesh_t cmesh, const int level, const t8_scheme_c *scheme);
+void t8_cmesh_set_refine (t8_cmesh_t cmesh, int level, t8_scheme_cxx_t *scheme);
 ```
 """
 function t8_cmesh_set_refine(cmesh, level, scheme)
-    @ccall libt8.t8_cmesh_set_refine(cmesh::t8_cmesh_t, level::Cint, scheme::Ptr{t8_scheme_c})::Cvoid
+    @ccall libt8.t8_cmesh_set_refine(cmesh::t8_cmesh_t, level::Cint, scheme::Ptr{t8_scheme_cxx_t})::Cvoid
 end
 
 """
@@ -3552,49 +3726,13 @@ function t8_cmesh_set_dimension(cmesh, dim)
 end
 
 """
-    t8_eclass
-
-This enumeration contains all possible element classes.
-
-| Enumerator             | Note                                                                                                               |
-| :--------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| T8\\_ECLASS\\_ZERO     | Zero-dimensional element class.                                                                                    |
-| T8\\_ECLASS\\_VERTEX   | The vertex is the only zero-dimensional element class.                                                             |
-| T8\\_ECLASS\\_LINE     | The line is the only one-dimensional element class.                                                                |
-| T8\\_ECLASS\\_QUAD     | The quadrilateral is one of two element classes in two dimensions.                                                 |
-| T8\\_ECLASS\\_TRIANGLE | The element class for a triangle.                                                                                  |
-| T8\\_ECLASS\\_HEX      | The hexahedron is one three-dimensional element class.                                                             |
-| T8\\_ECLASS\\_TET      | The tetrahedron is another three-dimensional element class.                                                        |
-| T8\\_ECLASS\\_PRISM    | The prism has five sides: two opposing triangles joined by three quadrilaterals.                                   |
-| T8\\_ECLASS\\_PYRAMID  | The pyramid has a quadrilateral as base and four triangles as sides.                                               |
-| T8\\_ECLASS\\_COUNT    | This is no element class but can be used as the number of element classes.                                         |
-| T8\\_ECLASS\\_INVALID  | This is no element class but can be used for the case a class of a third party library is not supported by t8code  |
-"""
-@cenum t8_eclass::UInt32 begin
-    T8_ECLASS_ZERO = 0
-    T8_ECLASS_VERTEX = 0
-    T8_ECLASS_LINE = 1
-    T8_ECLASS_QUAD = 2
-    T8_ECLASS_TRIANGLE = 3
-    T8_ECLASS_HEX = 4
-    T8_ECLASS_TET = 5
-    T8_ECLASS_PRISM = 6
-    T8_ECLASS_PYRAMID = 7
-    T8_ECLASS_COUNT = 8
-    T8_ECLASS_INVALID = 9
-end
-
-"""This enumeration contains all possible element classes."""
-const t8_eclass_t = t8_eclass
-
-"""
     t8_cmesh_set_tree_class(cmesh, gtree_id, tree_class)
 
 Set the class of a tree in the cmesh. It is not allowed to call this function after t8_cmesh_commit. It is not allowed to call this function multiple times for the same tree.
 
 # Arguments
 * `cmesh`:\\[in,out\\] The cmesh to be updated.
-* `gtree_id`:\\[in\\] The global number of the tree.
+* `tree_id`:\\[in\\] The global number of the tree.
 * `tree_class`:\\[in\\] The element class of this tree.
 ### Prototype
 ```c
@@ -3707,17 +3845,13 @@ end
 
 Insert a face-connection between two trees in a cmesh.
 
-!!! note
-
-    The orientation is defined as: Let my\\_face and other\\_face be the two face numbers of the connecting trees. We chose a main\\_face from them as follows: Either both trees have the same element class, then the face with the lower face number is the main\\_face or the trees belong to different classes in which case the face belonging to the tree with the lower class according to the ordering triangle < quad, hex < tet < prism < pyramid, is the main\\_face. Then face corner 0 of the main\\_face connects to a face corner k in the other face. The face orientation is defined as the number k. If the classes are equal and my\\_face == other\\_face, treating either of both faces as the main\\_face leads to the same result. See https://arxiv.org/pdf/1611.02929.pdf for more details.
-
 # Arguments
 * `cmesh`:\\[in,out\\] The cmesh to be updated.
-* `gtree1`:\\[in\\] The tree id of the first of the two trees.
-* `gtree2`:\\[in\\] The tree id of the second of the two trees.
+* `tree1`:\\[in\\] The tree id of the first of the two trees.
+* `tree2`:\\[in\\] The tree id of the second of the two trees.
 * `face1`:\\[in\\] The face number of the first tree.
 * `face2`:\\[in\\] The face number of the second tree.
-* `orientation`:\\[in\\] Specify how face1 and face2 are oriented to each other
+* `orientation`:\\[in\\] Specify how face1 and face2 are oriented to each other TODO: orientation needs to be carefully defined for all element classes. TODO: document orientation
 ### Prototype
 ```c
 void t8_cmesh_set_join (t8_cmesh_t cmesh, t8_gloidx_t gtree1, t8_gloidx_t gtree2, int face1, int face2, int orientation);
@@ -3859,15 +3993,6 @@ end
 """
     t8_cmesh_save(cmesh, fileprefix)
 
-Save the cmesh to a file with the given fileprefix.
-
-!!! note
-
-    Currently, it is only legal to save cmeshes that use the linear geometry.
-
-# Arguments
-* `cmesh`:\\[in\\] The cmesh to save.
-* `fileprefix`:\\[in\\] The prefix of the file to save the cmesh to.
 ### Prototype
 ```c
 int t8_cmesh_save (t8_cmesh_t cmesh, const char *fileprefix);
@@ -3896,11 +4021,10 @@ This enumeration contains all modes in which we can open a saved cmesh. The cmes
 
 | Enumerator         | Note                                                                                                                                                                                                                      |
 | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T8\\_LOAD\\_FIRST  | First mode.                                                                                                                                                                                                               |
 | T8\\_LOAD\\_SIMPLE | In simple mode, the first n processes load the file                                                                                                                                                                       |
 | T8\\_LOAD\\_BGQ    | In BGQ mode, the file is loaded on n nodes and from one process of each node. This needs MPI Version 3.1 or higher.                                                                                                       |
 | T8\\_LOAD\\_STRIDE | Every n-th process loads a file. Handle with care, we introduce it, since on Juqueen MPI-3 was not available. The parameter n has to be passed as an extra parameter.  # See also [`t8_cmesh_load_and_distribute`](@ref)  |
-| T8\\_LOAD\\_COUNT  | Number of modes in which we can open a saved cmesh.                                                                                                                                                                       |
+| T8\\_LOAD\\_COUNT  |                                                                                                                                                                                                                           |
 """
 @cenum t8_load_mode::UInt32 begin
     T8_LOAD_FIRST = 0
@@ -4182,7 +4306,7 @@ Return the eclass of a given local tree. TODO: Should we refer to indices or con
 
 # Arguments
 * `cmesh`:\\[in\\] The cmesh to be considered.
-* `ltree_id`:\\[in\\] The local id of the tree whose eclass will be returned.
+* `tree_id`:\\[in\\] The local id of the tree whose eclass will be returned.
 # Returns
 The eclass of the given tree. TODO: Call tree ids ltree\\_id or gtree\\_id etc. instead of tree\\_id. *cmesh* must be committed before calling this function.
 ### Prototype
@@ -4221,7 +4345,7 @@ Return the eclass of a given local ghost. TODO: Should we refer to indices or co
 
 # Arguments
 * `cmesh`:\\[in\\] The cmesh to be considered.
-* `lghost_id`:\\[in\\] The local id of the ghost whose eclass will be returned. 0 <= *tree_id* < cmesh.num\\_ghosts.
+* `ghost_id`:\\[in\\] The local id of the ghost whose eclass will be returned. 0 <= *tree_id* < cmesh.num\\_ghosts.
 # Returns
 The eclass of the given ghost. *cmesh* must be committed before calling this function.
 ### Prototype
@@ -4307,26 +4431,6 @@ function t8_cmesh_get_face_neighbor(cmesh, ltreeid, face, dual_face, orientation
 end
 
 """
-    t8_cmesh_get_tree_face_neighbor_eclass(cmesh, ltreeid, face)
-
-Given a local tree id (of a local tree or ghost tree) and a face compute the eclass of the  tree's face neighbor.
-
-# Arguments
-* `cmesh`:\\[in\\] The cmesh to be considered.
-* `ltreeid`:\\[in\\] The local id of a tree or a ghost.
-* `face`:\\[in\\] A face number of the tree/ghost.
-# Returns
-The eclass of a neighbor tree of *ltreeid* across *face*. T8\\_ECLASS\\_INVALID if no neighbor exists.
-### Prototype
-```c
-t8_eclass_t t8_cmesh_get_tree_face_neighbor_eclass (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid, const int face);
-```
-"""
-function t8_cmesh_get_tree_face_neighbor_eclass(cmesh, ltreeid, face)
-    @ccall libt8.t8_cmesh_get_tree_face_neighbor_eclass(cmesh::t8_cmesh_t, ltreeid::t8_locidx_t, face::Cint)::t8_eclass_t
-end
-
-"""
     t8_cmesh_print_profile(cmesh)
 
 Print the collected statistics from a cmesh profile.
@@ -4379,7 +4483,7 @@ Return the attribute pointer of a tree.
 * `cmesh`:\\[in\\] The cmesh.
 * `package_id`:\\[in\\] The identifier of a valid software package.
 * `key`:\\[in\\] A key used to identify the attribute under all attributes of this tree with the same *package_id*.
-* `ltree_id`:\\[in\\] The local number of the tree.
+* `tree_id`:\\[in\\] The local number of the tree.
 # Returns
 The attribute pointer of the tree *ltree_id* or NULL if the attribute is not found.
 # See also
@@ -4412,7 +4516,7 @@ Return the attribute pointer of a tree for a gloidx\\_t array.
 * `package_id`:\\[in\\] The identifier of a valid software package.
 * `key`:\\[in\\] A key used to identify the attribute under all attributes of this tree with the same *package_id*.
 * `ltree_id`:\\[in\\] The local number of the tree.
-* `data_count`:\\[in\\] The number of entries in the array that are requested. This must be smaller or equal to the *data_count* parameter of the corresponding call to t8_cmesh_set_attribute_gloidx_array
+* `data_count`:\\[in\\] The number of entries in the array that are requested.  This must be smaller or equal to the *data_count* parameter of the corresponding call to t8_cmesh_set_attribute_gloidx_array
 # Returns
 The attribute pointer of the tree *ltree_id* or NULL if the attribute is not found.
 # See also
@@ -4446,38 +4550,26 @@ function t8_cmesh_get_partition_table(cmesh)
 end
 
 """
-    t8_cmesh_uniform_bounds_equal_element_count(cmesh, level, tree_scheme, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared)
+    t8_cmesh_uniform_bounds(cmesh, level, ts, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared)
 
 Calculate the section of a uniform forest for the current rank.
 
 # Arguments
 * `cmesh`:\\[in\\] The cmesh to be considered.
 * `level`:\\[in\\] The uniform refinement level to be created.
-* `tree_scheme`:\\[in\\] The element scheme for which to compute the bounds.
+* `ts`:\\[in\\] The element scheme for which to compute the bounds.
 * `first_local_tree`:\\[out\\] The first tree that contains elements belonging to the calling processor.
-* `child_in_tree_begin`:\\[out\\] The tree-local index of the first element belonging to the calling processor. Not computed if NULL.
+* `child_in_tree_begin`:\\[out\\] The global index of the first element belonging to the calling processor. Not computed if NULL.
 * `last_local_tree`:\\[out\\] The last tree that contains elements belonging to the calling processor.
-* `child_in_tree_end`:\\[out\\] The tree-local index of the first element that does not belonging to the calling processor anymore. Not computed if NULL.
-* `first_tree_shared`:\\[out\\] If not NULL, 1 or 0 is stored here depending on whether *first_local_tree* is the same as *last_local_tree* on the previous process. *cmesh* must be committed before calling this function.
+* `child_in_tree_end`:\\[out\\] The global index of the first element that does not belonging to the calling processor anymore. Not computed if NULL.
+* `first_tree_shared`:\\[out\\] If not NULL, 1 or 0 is stored here depending on whether *first_local_tree* is the same as *last_local_tree* on the next process. *cmesh* must be committed before calling this function. *
 ### Prototype
 ```c
-void t8_cmesh_uniform_bounds_equal_element_count (t8_cmesh_t cmesh, const int level, const t8_scheme_c *tree_scheme, t8_gloidx_t *first_local_tree, t8_gloidx_t *child_in_tree_begin, t8_gloidx_t *last_local_tree, t8_gloidx_t *child_in_tree_end, int8_t *first_tree_shared);
+void t8_cmesh_uniform_bounds (t8_cmesh_t cmesh, int level, const t8_scheme_cxx_t *ts, t8_gloidx_t *first_local_tree, t8_gloidx_t *child_in_tree_begin, t8_gloidx_t *last_local_tree, t8_gloidx_t *child_in_tree_end, int8_t *first_tree_shared);
 ```
 """
-function t8_cmesh_uniform_bounds_equal_element_count(cmesh, level, tree_scheme, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared)
-    @ccall libt8.t8_cmesh_uniform_bounds_equal_element_count(cmesh::t8_cmesh_t, level::Cint, tree_scheme::Ptr{t8_scheme_c}, first_local_tree::Ptr{t8_gloidx_t}, child_in_tree_begin::Ptr{t8_gloidx_t}, last_local_tree::Ptr{t8_gloidx_t}, child_in_tree_end::Ptr{t8_gloidx_t}, first_tree_shared::Ptr{Int8})::Cvoid
-end
-
-"""
-    t8_cmesh_uniform_bounds_for_irregular_refinement(cmesh, level, scheme, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared, comm)
-
-### Prototype
-```c
-void t8_cmesh_uniform_bounds_for_irregular_refinement (const t8_cmesh_t cmesh, const int level, const t8_scheme_c *scheme, t8_gloidx_t *first_local_tree, t8_gloidx_t *child_in_tree_begin, t8_gloidx_t *last_local_tree, t8_gloidx_t *child_in_tree_end, int8_t *first_tree_shared, sc_MPI_Comm comm);
-```
-"""
-function t8_cmesh_uniform_bounds_for_irregular_refinement(cmesh, level, scheme, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared, comm)
-    @ccall libt8.t8_cmesh_uniform_bounds_for_irregular_refinement(cmesh::t8_cmesh_t, level::Cint, scheme::Ptr{t8_scheme_c}, first_local_tree::Ptr{t8_gloidx_t}, child_in_tree_begin::Ptr{t8_gloidx_t}, last_local_tree::Ptr{t8_gloidx_t}, child_in_tree_end::Ptr{t8_gloidx_t}, first_tree_shared::Ptr{Int8}, comm::MPI_Comm)::Cvoid
+function t8_cmesh_uniform_bounds(cmesh, level, ts, first_local_tree, child_in_tree_begin, last_local_tree, child_in_tree_end, first_tree_shared)
+    @ccall libt8.t8_cmesh_uniform_bounds(cmesh::t8_cmesh_t, level::Cint, ts::Ptr{t8_scheme_cxx_t}, first_local_tree::Ptr{t8_gloidx_t}, child_in_tree_begin::Ptr{t8_gloidx_t}, last_local_tree::Ptr{t8_gloidx_t}, child_in_tree_end::Ptr{t8_gloidx_t}, first_tree_shared::Ptr{Int8})::Cvoid
 end
 
 """
@@ -4519,6 +4611,7 @@ Verify that a coarse mesh has only one reference left and destroy it. This funct
 
 # Arguments
 * `pcmesh`:\\[in,out\\] This cmesh must have a reference count of one. It can be in any state (committed or not). Then it effectively calls t8_cmesh_unref.
+* `comm`:\\[in\\] A mpi communicator that is valid with *cmesh*.
 ### Prototype
 ```c
 void t8_cmesh_destroy (t8_cmesh_t *pcmesh);
@@ -4526,6 +4619,18 @@ void t8_cmesh_destroy (t8_cmesh_t *pcmesh);
 """
 function t8_cmesh_destroy(pcmesh)
     @ccall libt8.t8_cmesh_destroy(pcmesh::Ptr{t8_cmesh_t})::Cvoid
+end
+
+"""
+    t8_cmesh_new_testhybrid(comm)
+
+### Prototype
+```c
+t8_cmesh_t t8_cmesh_new_testhybrid (sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_new_testhybrid(comm)
+    @ccall libt8.t8_cmesh_new_testhybrid(comm::MPI_Comm)::t8_cmesh_t
 end
 
 """
@@ -4551,7 +4656,7 @@ end
 """
     t8_cmesh_translate_coordinates(coords_in, coords_out, num_vertices, translate)
 
-Compute y = x + translate on an array of doubles, interpreting each 3 as one vector x
+Compute y = x + translate on an array of doubles, interpreting  each 3 as one vector x
 
 # Arguments
 * `coords_in`:\\[in\\] The incoming coordinates of the vectors
@@ -4594,22 +4699,3623 @@ function t8_cmesh_debug_print_trees(cmesh, comm)
 end
 
 """
-    t8_cmesh_get_local_bounding_box(cmesh, bounds)
+    t8_netcdf_variable_type
 
-Compute the process local bounding box of the cmesh. The bounding box is stored in the array *bounds* in the following order: bounds[0] = x\\_min bounds[1] = x\\_max bounds[2] = y\\_min bounds[3] = y\\_max bounds[4] = z\\_min bounds[5] = z\\_max
+This enumeration contains all possible netCDF variable datatypes (int, int64, double).
 
-# Arguments
-* `cmesh`:\\[in\\] The cmesh to be considered.
-* `bounds`:\\[out\\] The bounding box of the cmesh. If the box is flat (for quads for example, z\\_min == z\\_max)
-# Returns
-True if the computation was successful, false if the cmesh is empty.
+| Enumerator           | Note                                                                 |
+| :------------------- | :------------------------------------------------------------------- |
+| T8\\_NETCDF\\_INT    | Symbolizes netCDF variable datatype which holds 32-bit integer data  |
+| T8\\_NETCDF\\_INT64  | Symbolizes netCDF variable datatype which holds 64-bit integer data  |
+| T8\\_NETCDF\\_DOUBLE | Symbolizes netCDF variable datatype which holds double data          |
+"""
+@cenum t8_netcdf_variable_type::UInt32 begin
+    T8_NETCDF_INT = 0
+    T8_NETCDF_INT64 = 1
+    T8_NETCDF_DOUBLE = 2
+end
+
+"""This enumeration contains all possible netCDF variable datatypes (int, int64, double)."""
+const t8_netcdf_variable_type_t = t8_netcdf_variable_type
+
+struct t8_netcdf_variable_t
+    variable_name::Cstring
+    variable_long_name::Cstring
+    variable_units::Cstring
+    datatype::t8_netcdf_variable_type_t
+    var_user_dimid::Cint
+    var_user_data::Ptr{sc_array_t}
+end
+
+"""
+    t8_cmesh_write_netcdf(cmesh, file_prefix, file_title, dim, num_extern_netcdf_vars, variables, comm)
+
 ### Prototype
 ```c
-int t8_cmesh_get_local_bounding_box (const t8_cmesh_t cmesh, double bounds[6]);
+void t8_cmesh_write_netcdf (t8_cmesh_t cmesh, const char *file_prefix, const char *file_title, int dim, int num_extern_netcdf_vars, t8_netcdf_variable_t *variables[], sc_MPI_Comm comm);
 ```
 """
-function t8_cmesh_get_local_bounding_box(cmesh, bounds)
-    @ccall libt8.t8_cmesh_get_local_bounding_box(cmesh::t8_cmesh_t, bounds::Ptr{Cdouble})::Cint
+function t8_cmesh_write_netcdf(cmesh, file_prefix, file_title, dim, num_extern_netcdf_vars, variables, comm)
+    @ccall libt8.t8_cmesh_write_netcdf(cmesh::t8_cmesh_t, file_prefix::Cstring, file_title::Cstring, dim::Cint, num_extern_netcdf_vars::Cint, variables::Ptr{Ptr{t8_netcdf_variable_t}}, comm::MPI_Comm)::Cvoid
+end
+
+struct t8_msh_file_node_t
+    index::t8_locidx_t
+    coordinates::NTuple{3, Cdouble}
+end
+
+struct t8_msh_file_node_parametric_t
+    index::t8_locidx_t
+    coordinates::NTuple{3, Cdouble}
+    parameters::NTuple{2, Cdouble}
+    parametric::Cint
+    entity_dim::Cint
+    entity_tag::t8_locidx_t
+end
+
+"""
+    t8_cmesh_from_msh_file(fileprefix, partition, comm, dim, master, use_cad_geometry)
+
+### Prototype
+```c
+t8_cmesh_t t8_cmesh_from_msh_file (const char *fileprefix, int partition, sc_MPI_Comm comm, int dim, int master, int use_cad_geometry);
+```
+"""
+function t8_cmesh_from_msh_file(fileprefix, partition, comm, dim, master, use_cad_geometry)
+    @ccall libt8.t8_cmesh_from_msh_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, dim::Cint, master::Cint, use_cad_geometry::Cint)::t8_cmesh_t
+end
+
+struct sc_stats
+    mpicomm::MPI_Comm
+    sarray::Ptr{sc_array_t}
+end
+
+"""The statistics container allows dynamically adding random variables."""
+const sc_statistics_t = sc_stats
+
+"""
+    sc_statistics_has(stats, name)
+
+Returns true if the stats include a variable with the given name
+
+### Prototype
+```c
+int sc_statistics_has (sc_statistics_t * stats, const char *name);
+```
+"""
+function sc_statistics_has(stats, name)
+    @ccall libsc.sc_statistics_has(stats::Ptr{sc_statistics_t}, name::Cstring)::Cint
+end
+
+"""
+    sc_statistics_add_empty(stats, name)
+
+Register a statistics variable by name and set its count to 0. This variable must not exist already.
+
+### Prototype
+```c
+void sc_statistics_add_empty (sc_statistics_t * stats, const char *name);
+```
+"""
+function sc_statistics_add_empty(stats, name)
+    @ccall libsc.sc_statistics_add_empty(stats::Ptr{sc_statistics_t}, name::Cstring)::Cvoid
+end
+
+struct sc_flopinfo
+    seconds::Cdouble
+    cwtime::Cdouble
+    crtime::Cfloat
+    cptime::Cfloat
+    cflpops::Clonglong
+    iwtime::Cdouble
+    irtime::Cfloat
+    iptime::Cfloat
+    iflpops::Clonglong
+    mflops::Cfloat
+    use_papi::Cint
+end
+
+const sc_flopinfo_t = sc_flopinfo
+
+"""
+    sc_flops_snap(fi, snapshot)
+
+Call [`sc_flops_count`](@ref) (fi) and copies fi into snapshot.
+
+# Arguments
+* `fi`:\\[in,out\\] Members will be updated.
+* `snapshot`:\\[out\\] On output is a copy of fi.
+### Prototype
+```c
+void sc_flops_snap (sc_flopinfo_t * fi, sc_flopinfo_t * snapshot);
+```
+"""
+function sc_flops_snap(fi, snapshot)
+    @ccall libsc.sc_flops_snap(fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t})::Cvoid
+end
+
+"""
+    sc_flops_shot(fi, snapshot)
+
+Call [`sc_flops_count`](@ref) (fi) and override snapshot interval timings with the differences since the previous call to [`sc_flops_snap`](@ref). The interval mflop rate is computed by iflpops / 1e6 / irtime. The cumulative timings in snapshot are copied form fi.
+
+# Arguments
+* `fi`:\\[in,out\\] Members will be updated.
+* `snapshot`:\\[in,out\\] Interval timings measured since [`sc_flops_snap`](@ref).
+### Prototype
+```c
+void sc_flops_shot (sc_flopinfo_t * fi, sc_flopinfo_t * snapshot);
+```
+"""
+function sc_flops_shot(fi, snapshot)
+    @ccall libsc.sc_flops_shot(fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t})::Cvoid
+end
+
+"""
+    sc_statistics_accumulate(stats, name, value)
+
+Add an instance of a statistics variable, see [`sc_stats_accumulate`](@ref) The variable must previously be added with [`sc_statistics_add_empty`](@ref).
+
+### Prototype
+```c
+void sc_statistics_accumulate (sc_statistics_t * stats, const char *name, double value);
+```
+"""
+function sc_statistics_accumulate(stats, name, value)
+    @ccall libsc.sc_statistics_accumulate(stats::Ptr{sc_statistics_t}, name::Cstring, value::Cdouble)::Cvoid
+end
+
+"""
+    sc_flops_papi(rtime, ptime, flpops, mflops)
+
+Calls PAPI\\_flops. Aborts on PAPI error. The first call sets up the performance counters. Subsequent calls return cumulative real and process times, cumulative floating point operations and the flop rate since the last call. This is a compatibility wrapper: users should only need to use the [`sc_flopinfo_t`](@ref) interface functions below.
+
+### Prototype
+```c
+void sc_flops_papi (float *rtime, float *ptime, long long *flpops, float *mflops);
+```
+"""
+function sc_flops_papi(rtime, ptime, flpops, mflops)
+    @ccall libsc.sc_flops_papi(rtime::Ptr{Cfloat}, ptime::Ptr{Cfloat}, flpops::Ptr{Clonglong}, mflops::Ptr{Cfloat})::Cvoid
+end
+
+"""
+    sc_flops_start(fi)
+
+Prepare [`sc_flopinfo_t`](@ref) structure and start flop counters. Must only be called once during the program run. This function calls [`sc_flops_papi`](@ref).
+
+# Arguments
+* `fi`:\\[out\\] Members will be initialized.
+### Prototype
+```c
+void sc_flops_start (sc_flopinfo_t * fi);
+```
+"""
+function sc_flops_start(fi)
+    @ccall libsc.sc_flops_start(fi::Ptr{sc_flopinfo_t})::Cvoid
+end
+
+"""
+    sc_flops_start_nopapi(fi)
+
+Prepare [`sc_flopinfo_t`](@ref) structure and ignore the flop counters. This [`sc_flopinfo_t`](@ref) does not call PAPI\\_flops() in this function or in [`sc_flops_count`](@ref)().
+
+# Arguments
+* `fi`:\\[out\\] Members will be initialized.
+### Prototype
+```c
+void sc_flops_start_nopapi (sc_flopinfo_t * fi);
+```
+"""
+function sc_flops_start_nopapi(fi)
+    @ccall libsc.sc_flops_start_nopapi(fi::Ptr{sc_flopinfo_t})::Cvoid
+end
+
+"""
+    sc_flops_count(fi)
+
+Update [`sc_flopinfo_t`](@ref) structure with current measurement. Must only be called after [`sc_flops_start`](@ref). Can be called any number of times. This function calls [`sc_flops_papi`](@ref).
+
+# Arguments
+* `fi`:\\[in,out\\] Members will be updated.
+### Prototype
+```c
+void sc_flops_count (sc_flopinfo_t * fi);
+```
+"""
+function sc_flops_count(fi)
+    @ccall libsc.sc_flops_count(fi::Ptr{sc_flopinfo_t})::Cvoid
+end
+
+# automatic type deduction for variadic arguments may not be what you want, please use with caution
+@generated function sc_flops_shotv(fi, va_list...)
+        :(@ccall(libsc.sc_flops_shotv(fi::Ptr{sc_flopinfo_t}; $(to_c_type_pairs(va_list)...))::Cvoid))
+    end
+
+"""
+    sc_keyvalue_entry_type_t
+
+The values can have different types.
+
+| Enumerator                      | Note                                        |
+| :------------------------------ | :------------------------------------------ |
+| SC\\_KEYVALUE\\_ENTRY\\_NONE    | Designate an invalid situation.             |
+| SC\\_KEYVALUE\\_ENTRY\\_INT     | Used for values of type int.                |
+| SC\\_KEYVALUE\\_ENTRY\\_DOUBLE  | Used for values of type double.             |
+| SC\\_KEYVALUE\\_ENTRY\\_STRING  | Used for values of type const char *.       |
+| SC\\_KEYVALUE\\_ENTRY\\_POINTER | Used for values of anonymous pointer type.  |
+"""
+@cenum sc_keyvalue_entry_type_t::UInt32 begin
+    SC_KEYVALUE_ENTRY_NONE = 0
+    SC_KEYVALUE_ENTRY_INT = 1
+    SC_KEYVALUE_ENTRY_DOUBLE = 2
+    SC_KEYVALUE_ENTRY_STRING = 3
+    SC_KEYVALUE_ENTRY_POINTER = 4
+end
+
+mutable struct sc_keyvalue end
+
+"""The key-value container is an opaque structure."""
+
+# no prototype is found for this function at sc_keyvalue.h:54:21, please use with caution
+"""
+    sc_keyvalue_new()
+
+Create a new key-value container.
+
+# Returns
+The container is ready to use.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_new()
+end
+
+# automatic type deduction for variadic arguments may not be what you want, please use with caution
+@generated function sc_keyvalue_newf(dummy, va_list...)
+    end
+
+"""
+    sc_keyvalue_destroy(kv)
+
+Free a key-value container and all internal memory for key storage.
+
+# Arguments
+* `kv`:\\[in,out\\] The key-value container is invalidated by this call.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_destroy(kv)
+end
+
+"""
+    sc_keyvalue_exists(kv, key)
+
+Routine to check existence of an entry.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key to query.
+# Returns
+The entry's type if found and SC\\_KEYVALUE\\_ENTRY\\_NONE otherwise.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_exists(kv, key)
+end
+
+"""
+    sc_keyvalue_unset(kv, key)
+
+Routine to remove an entry.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key to remove if it exists.
+# Returns
+The entry's type if found and removed, SC\\_KEYVALUE\\_ENTRY\\_NONE otherwise.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_unset(kv, key)
+end
+
+"""
+    sc_keyvalue_get_int(kv, key, dvalue)
+
+Routines to retrieve an integer value by its key. This function asserts that the key, if existing, points to the correct type.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key, may or may not exist.
+* `dvalue`:\\[in\\] Default value returned if key is not found.
+# Returns
+If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_get_int(kv, key, dvalue)
+end
+
+"""
+    sc_keyvalue_get_double(kv, key, dvalue)
+
+Retrieve a double value by its key. This function asserts that the key, if existing, points to the correct type.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key, may or may not exist.
+* `dvalue`:\\[in\\] Default value returned if key is not found.
+# Returns
+If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_get_double(kv, key, dvalue)
+end
+
+"""
+    sc_keyvalue_get_string(kv, key, dvalue)
+
+Retrieve a string value by its key. This function asserts that the key, if existing, points to the correct type.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key, may or may not exist.
+* `dvalue`:\\[in\\] Default value returned if key is not found.
+# Returns
+If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_get_string(kv, key, dvalue)
+end
+
+"""
+    sc_keyvalue_get_pointer(kv, key, dvalue)
+
+Retrieve a pointer value by its key. This function asserts that the key, if existing, points to the correct type.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `key`:\\[in\\] Lookup key, may or may not exist.
+* `dvalue`:\\[in\\] Default value returned if key is not found.
+# Returns
+If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_get_pointer(kv, key, dvalue)
+end
+
+"""
+    sc_keyvalue_get_int_check(kv, key, status)
+
+Query an integer key with error checking. We check whether the key is not found or it is of the wrong type. A default value to be returned on error can be passed in as *status. If status is NULL, then the result on error is undefined.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value table.
+* `key`:\\[in\\] Non-NULL key string.
+* `status`:\\[in,out\\] If not NULL, set to 0 if there is no error, 1 if the key is not found, 2 if a value is found but its type is not integer, and return the input value *status on error.
+# Returns
+On error we return *status if status is not NULL, and else an undefined value backed by an assertion. Without error, return the result of the lookup.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_get_int_check(kv, key, status)
+end
+
+"""
+    sc_keyvalue_set_int(kv, key, newvalue)
+
+Routine to set an integer value for a given key.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value table.
+* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type integer.
+* `newvalue`:\\[in\\] New value will be stored under key.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_set_int(kv, key, newvalue)
+end
+
+"""
+    sc_keyvalue_set_double(kv, key, newvalue)
+
+Routine to set a double value for a given key.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value table.
+* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type double.
+* `newvalue`:\\[in\\] New value will be stored under key.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_set_double(kv, key, newvalue)
+end
+
+"""
+    sc_keyvalue_set_string(kv, key, newvalue)
+
+Routine to set a string value for a given key.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value table.
+* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type string.
+* `newvalue`:\\[in\\] New value will be stored under key.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_set_string(kv, key, newvalue)
+end
+
+"""
+    sc_keyvalue_set_pointer(kv, key, newvalue)
+
+Routine to set a pointer value for a given key.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value table.
+* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type pointer.
+* `newvalue`:\\[in\\] New value will be stored under key.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_set_pointer(kv, key, newvalue)
+end
+
+# typedef int ( * sc_keyvalue_foreach_t ) ( const char * key , const sc_keyvalue_entry_type_t type , void * entry , const void * u )
+"""
+Function to call on every key value pair
+
+# Arguments
+* `key`:\\[in\\] The key for this pair
+* `type`:\\[in\\] The type of entry
+* `entry`:\\[in\\] Pointer to the entry
+* `u`:\\[in\\] Arbitrary user data.
+# Returns
+Return true if the traversal should continue, false to stop.
+"""
+const sc_keyvalue_foreach_t = Ptr{Cvoid}
+
+"""
+    sc_keyvalue_foreach(kv, fn, user_data)
+
+Iterate through all stored key-value pairs.
+
+# Arguments
+* `kv`:\\[in\\] Valid key-value container.
+* `fn`:\\[in\\] Function to call on each key-value pair.
+* `user_data`:\\[in,out\\] This pointer is passed through to **fn**.
+### Prototype
+```c
+```
+"""
+function sc_keyvalue_foreach(kv, fn, user_data)
+end
+
+"""
+    sc_statinfo
+
+Store information of one random variable.
+
+| Field            | Note                                     |
+| :--------------- | :--------------------------------------- |
+| dirty            | Only update stats if this is true.       |
+| count            | Inout; global count is 52 bit accurate.  |
+| sum\\_values     | Inout; global sum of values.             |
+| sum\\_squares    | Inout; global sum of squares.            |
+| min              | Inout; minimum over values.              |
+| max              | Inout; maximum over values.              |
+| variable         | Name of the variable for output.         |
+| variable\\_owned | NULL or deep copy of variable.           |
+| group            | Grouping identifier.                     |
+| prio             | Priority identifier.                     |
+"""
+struct sc_statinfo
+    dirty::Cint
+    count::Clong
+    sum_values::Cdouble
+    sum_squares::Cdouble
+    min::Cdouble
+    max::Cdouble
+    min_at_rank::Cint
+    max_at_rank::Cint
+    average::Cdouble
+    variance::Cdouble
+    standev::Cdouble
+    variance_mean::Cdouble
+    standev_mean::Cdouble
+    variable::Cstring
+    variable_owned::Cstring
+    group::Cint
+    prio::Cint
+end
+
+"""Store information of one random variable."""
+const sc_statinfo_t = sc_statinfo
+
+"""
+    sc_stats_set1(stats, value, variable)
+
+Populate a [`sc_statinfo_t`](@ref) structure assuming count=1 and mark it dirty. We set sc_stats_group_all and sc_stats_prio_all internally.
+
+# Arguments
+* `stats`:\\[out\\] Will be filled with count=1 and the value.
+* `value`:\\[in\\] Value used to fill statistics information.
+* `variable`:\\[in\\] String to be reported by sc_stats_print. This string is assigned by pointer, not copied. Thus, it must stay alive while stats is in use.
+### Prototype
+```c
+void sc_stats_set1 (sc_statinfo_t * stats, double value, const char *variable);
+```
+"""
+function sc_stats_set1(stats, value, variable)
+    @ccall libsc.sc_stats_set1(stats::Ptr{sc_statinfo_t}, value::Cdouble, variable::Cstring)::Cvoid
+end
+
+"""
+    sc_stats_set1_ext(stats, value, variable, copy_variable, stats_group, stats_prio)
+
+Populate a [`sc_statinfo_t`](@ref) structure assuming count=1 and mark it dirty.
+
+# Arguments
+* `stats`:\\[out\\] Will be filled with count=1 and the value.
+* `value`:\\[in\\] Value used to fill statistics information.
+* `variable`:\\[in\\] String to be reported by sc_stats_print.
+* `copy_variable`:\\[in\\] If true, make internal copy of variable. Otherwise just assign the pointer.
+* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
+* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all.
+### Prototype
+```c
+void sc_stats_set1_ext (sc_statinfo_t * stats, double value, const char *variable, int copy_variable, int stats_group, int stats_prio);
+```
+"""
+function sc_stats_set1_ext(stats, value, variable, copy_variable, stats_group, stats_prio)
+    @ccall libsc.sc_stats_set1_ext(stats::Ptr{sc_statinfo_t}, value::Cdouble, variable::Cstring, copy_variable::Cint, stats_group::Cint, stats_prio::Cint)::Cvoid
+end
+
+"""
+    sc_stats_init(stats, variable)
+
+Initialize a [`sc_statinfo_t`](@ref) structure assuming count=0 and mark it dirty. This is useful if *stats* will be used to sc_stats_accumulate instances locally before global statistics are computed. We set sc_stats_group_all and sc_stats_prio_all internally.
+
+# Arguments
+* `stats`:\\[out\\] Will be filled with count 0 and values of 0.
+* `variable`:\\[in\\] String to be reported by sc_stats_print. This string is assigned by pointer, not copied. Thus, it must stay alive while stats is in use.
+### Prototype
+```c
+void sc_stats_init (sc_statinfo_t * stats, const char *variable);
+```
+"""
+function sc_stats_init(stats, variable)
+    @ccall libsc.sc_stats_init(stats::Ptr{sc_statinfo_t}, variable::Cstring)::Cvoid
+end
+
+"""
+    sc_stats_init_ext(stats, variable, copy_variable, stats_group, stats_prio)
+
+Initialize a [`sc_statinfo_t`](@ref) structure assuming count=0 and mark it dirty. This is useful if *stats* will be used to sc_stats_accumulate instances locally before global statistics are computed.
+
+# Arguments
+* `stats`:\\[out\\] Will be filled with count 0 and values of 0.
+* `variable`:\\[in\\] String to be reported by sc_stats_print.
+* `copy_variable`:\\[in\\] If true, make internal copy of variable. Otherwise just assign the pointer.
+* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
+* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all. Values increase by importance.
+### Prototype
+```c
+void sc_stats_init_ext (sc_statinfo_t * stats, const char *variable, int copy_variable, int stats_group, int stats_prio);
+```
+"""
+function sc_stats_init_ext(stats, variable, copy_variable, stats_group, stats_prio)
+    @ccall libsc.sc_stats_init_ext(stats::Ptr{sc_statinfo_t}, variable::Cstring, copy_variable::Cint, stats_group::Cint, stats_prio::Cint)::Cvoid
+end
+
+"""
+    sc_stats_reset(stats, reset_vgp)
+
+Reset all values to zero, optionally unassign name, group, and priority.
+
+# Arguments
+* `stats`:\\[in,out\\] Variables are zeroed. They can be set again by set1 or accumulate.
+* `reset_vgp`:\\[in\\] If true, the variable name string is zeroed and if we did a copy, the copy is freed. If true, group and priority are set to all. If false, we don't touch any of the above.
+### Prototype
+```c
+void sc_stats_reset (sc_statinfo_t * stats, int reset_vgp);
+```
+"""
+function sc_stats_reset(stats, reset_vgp)
+    @ccall libsc.sc_stats_reset(stats::Ptr{sc_statinfo_t}, reset_vgp::Cint)::Cvoid
+end
+
+"""
+    sc_stats_set_group_prio(stats, stats_group, stats_prio)
+
+Set/update the group and priority information for a stats item.
+
+# Arguments
+* `stats`:\\[out\\] Only group and stats entries are updated.
+* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
+* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all. Values increase by importance.
+### Prototype
+```c
+void sc_stats_set_group_prio (sc_statinfo_t * stats, int stats_group, int stats_prio);
+```
+"""
+function sc_stats_set_group_prio(stats, stats_group, stats_prio)
+    @ccall libsc.sc_stats_set_group_prio(stats::Ptr{sc_statinfo_t}, stats_group::Cint, stats_prio::Cint)::Cvoid
+end
+
+"""
+    sc_stats_accumulate(stats, value)
+
+Add an instance of the random variable. The counter of the variable is increased by one. The value is added into the present values of the variable.
+
+# Arguments
+* `stats`:\\[out\\] Must be dirty. We bump count and values.
+* `value`:\\[in\\] Value used to update statistics information.
+### Prototype
+```c
+void sc_stats_accumulate (sc_statinfo_t * stats, double value);
+```
+"""
+function sc_stats_accumulate(stats, value)
+    @ccall libsc.sc_stats_accumulate(stats::Ptr{sc_statinfo_t}, value::Cdouble)::Cvoid
+end
+
+"""
+    sc_stats_compute(mpicomm, nvars, stats)
+
+### Prototype
+```c
+void sc_stats_compute (sc_MPI_Comm mpicomm, int nvars, sc_statinfo_t * stats);
+```
+"""
+function sc_stats_compute(mpicomm, nvars, stats)
+    @ccall libsc.sc_stats_compute(mpicomm::MPI_Comm, nvars::Cint, stats::Ptr{sc_statinfo_t})::Cvoid
+end
+
+"""
+    sc_stats_compute1(mpicomm, nvars, stats)
+
+### Prototype
+```c
+void sc_stats_compute1 (sc_MPI_Comm mpicomm, int nvars, sc_statinfo_t * stats);
+```
+"""
+function sc_stats_compute1(mpicomm, nvars, stats)
+    @ccall libsc.sc_stats_compute1(mpicomm::MPI_Comm, nvars::Cint, stats::Ptr{sc_statinfo_t})::Cvoid
+end
+
+"""
+    sc_stats_print(package_id, log_priority, nvars, stats, full, summary)
+
+Print measured statistics. This function uses the `SC_LC_GLOBAL` log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler. All groups and priorities are printed.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `log_priority`:\\[in\\] Log priority for output according to sc.h.
+* `nvars`:\\[in\\] Number of stats items in input array.
+* `stats`:\\[in\\] Input array of stats variable items.
+* `full`:\\[in\\] Print full information for every variable.
+* `summary`:\\[in\\] Print summary information all on 1 line.
+### Prototype
+```c
+void sc_stats_print (int package_id, int log_priority, int nvars, sc_statinfo_t * stats, int full, int summary);
+```
+"""
+function sc_stats_print(package_id, log_priority, nvars, stats, full, summary)
+    @ccall libsc.sc_stats_print(package_id::Cint, log_priority::Cint, nvars::Cint, stats::Ptr{sc_statinfo_t}, full::Cint, summary::Cint)::Cvoid
+end
+
+"""
+    sc_stats_print_ext(package_id, log_priority, nvars, stats, stats_group, stats_prio, full, summary)
+
+Print measured statistics, filter by group and/or priority. This function uses the `SC_LC_GLOBAL` log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `log_priority`:\\[in\\] Log priority for output according to sc.h.
+* `nvars`:\\[in\\] Number of stats items in input array.
+* `stats`:\\[in\\] Input array of stats variable items.
+* `stats_group`:\\[in\\] Print only this group. Non-negative or sc_stats_group_all. We skip printing a variable if neither this parameter nor the item's group is all and if the item's group does not match this.
+* `stats_prio`:\\[in\\] Print this and higher priorities. Non-negative or sc_stats_prio_all. We skip printing a variable if neither this parameter nor the item's prio is all and if the item's prio is less than this.
+* `full`:\\[in\\] Print full information for every variable. This produces multiple lines including minimum, maximum, and standard deviation. If this is false, print one line per variable.
+* `summary`:\\[in\\] Print summary information all on 1 line. This always contains all variables. Not affected by stats\\_group and stats\\_prio.
+### Prototype
+```c
+void sc_stats_print_ext (int package_id, int log_priority, int nvars, sc_statinfo_t * stats, int stats_group, int stats_prio, int full, int summary);
+```
+"""
+function sc_stats_print_ext(package_id, log_priority, nvars, stats, stats_group, stats_prio, full, summary)
+    @ccall libsc.sc_stats_print_ext(package_id::Cint, log_priority::Cint, nvars::Cint, stats::Ptr{sc_statinfo_t}, stats_group::Cint, stats_prio::Cint, full::Cint, summary::Cint)::Cvoid
+end
+
+"""
+    sc_statistics_new(mpicomm)
+
+### Prototype
+```c
+sc_statistics_t *sc_statistics_new (sc_MPI_Comm mpicomm);
+```
+"""
+function sc_statistics_new(mpicomm)
+    @ccall libsc.sc_statistics_new(mpicomm::MPI_Comm)::Ptr{sc_statistics_t}
+end
+
+"""
+    sc_statistics_destroy(stats)
+
+Destroy a statistics structure.
+
+# Arguments
+* `stats`:\\[in,out\\] Valid object is invalidated.
+### Prototype
+```c
+void sc_statistics_destroy (sc_statistics_t * stats);
+```
+"""
+function sc_statistics_destroy(stats)
+    @ccall libsc.sc_statistics_destroy(stats::Ptr{sc_statistics_t})::Cvoid
+end
+
+"""
+    sc_statistics_add(stats, name)
+
+Register a statistics variable by name and set its value to 0. This variable must not exist already.
+
+### Prototype
+```c
+void sc_statistics_add (sc_statistics_t * stats, const char *name);
+```
+"""
+function sc_statistics_add(stats, name)
+    @ccall libsc.sc_statistics_add(stats::Ptr{sc_statistics_t}, name::Cstring)::Cvoid
+end
+
+"""
+    sc_statistics_set(stats, name, value)
+
+Set the value of a statistics variable, see [`sc_stats_set1`](@ref). The variable must previously be added with [`sc_statistics_add`](@ref). This assumes count=1 as in the [`sc_stats_set1`](@ref) function above.
+
+### Prototype
+```c
+void sc_statistics_set (sc_statistics_t * stats, const char *name, double value);
+```
+"""
+function sc_statistics_set(stats, name, value)
+    @ccall libsc.sc_statistics_set(stats::Ptr{sc_statistics_t}, name::Cstring, value::Cdouble)::Cvoid
+end
+
+"""
+    sc_statistics_compute(stats)
+
+Compute statistics for all variables, see [`sc_stats_compute`](@ref).
+
+### Prototype
+```c
+void sc_statistics_compute (sc_statistics_t * stats);
+```
+"""
+function sc_statistics_compute(stats)
+    @ccall libsc.sc_statistics_compute(stats::Ptr{sc_statistics_t})::Cvoid
+end
+
+"""
+    sc_statistics_print(stats, package_id, log_priority, full, summary)
+
+Print all statistics variables, see [`sc_stats_print`](@ref).
+
+### Prototype
+```c
+void sc_statistics_print (sc_statistics_t * stats, int package_id, int log_priority, int full, int summary);
+```
+"""
+function sc_statistics_print(stats, package_id, log_priority, full, summary)
+    @ccall libsc.sc_statistics_print(stats::Ptr{sc_statistics_t}, package_id::Cint, log_priority::Cint, full::Cint, summary::Cint)::Cvoid
+end
+
+mutable struct sc_options end
+
+"""The options data structure is opaque."""
+const sc_options_t = sc_options
+
+# typedef int ( * sc_options_callback_t ) ( sc_options_t * opt , const char * opt_arg , void * data )
+"""
+This callback can be invoked with sc_options_parse.
+
+# Arguments
+* `opt`:\\[in\\] Valid options data structure. This is passed as a matter of principle.
+* `opt_arg`:\\[in\\] The option argument or NULL if there is none. This variable is internal. Do not store pointer.
+* `data`:\\[in\\] User-defined data passed to [`sc_options_add_callback`](@ref).
+# Returns
+Return 0 if successful, -1 to indicate a parse error.
+"""
+const sc_options_callback_t = Ptr{Cvoid}
+
+"""
+    sc_options_new(program_path)
+
+Create an empty options structure.
+
+# Arguments
+* `program_path`:\\[in\\] Name or path name of the program to display. Usually argv[0] is fine.
+# Returns
+A valid and empty options structure.
+### Prototype
+```c
+sc_options_t *sc_options_new (const char *program_path);
+```
+"""
+function sc_options_new(program_path)
+    @ccall libsc.sc_options_new(program_path::Cstring)::Ptr{sc_options_t}
+end
+
+"""
+    sc_options_destroy_deep(opt)
+
+Destroy the options structure and all allocated structures contained. The keyvalue structure passed into sc\\_keyvalue\\_add is destroyed.
+
+!!! compat "Deprecated"
+
+    This function is kept for backwards compatibility. It is best to destroy any key-value container outside of the lifetime of the options object.
+
+# Arguments
+* `opt`:\\[in,out\\] This options structure is deallocated, including all key-value containers referenced.
+### Prototype
+```c
+void sc_options_destroy_deep (sc_options_t * opt);
+```
+"""
+function sc_options_destroy_deep(opt)
+    @ccall libsc.sc_options_destroy_deep(opt::Ptr{sc_options_t})::Cvoid
+end
+
+"""
+    sc_options_destroy(opt)
+
+Destroy the options structure. Whatever has been passed into sc\\_keyvalue\\_add is left alone.
+
+# Arguments
+* `opt`:\\[in,out\\] This options structure is deallocated.
+### Prototype
+```c
+void sc_options_destroy (sc_options_t * opt);
+```
+"""
+function sc_options_destroy(opt)
+    @ccall libsc.sc_options_destroy(opt::Ptr{sc_options_t})::Cvoid
+end
+
+"""
+    sc_options_set_spacing(opt, space_type, space_help)
+
+Set the spacing for sc_options_print_summary. There are two values to be set: the spacing from the beginning of the printed line to the type of the option variable, and from the beginning of the printed line to the help string.
+
+# Arguments
+* `opt`:\\[in,out\\] Valid options structure.
+* `space_type`:\\[in\\] Number of spaces to the type display, for example <INT>, <STRING>, etc. Setting this negative sets the default 20.
+* `space_help`:\\[in\\] Number of space to the help string. Setting this negative sets the default 32.
+### Prototype
+```c
+void sc_options_set_spacing (sc_options_t * opt, int space_type, int space_help);
+```
+"""
+function sc_options_set_spacing(opt, space_type, space_help)
+    @ccall libsc.sc_options_set_spacing(opt::Ptr{sc_options_t}, space_type::Cint, space_help::Cint)::Cvoid
+end
+
+"""
+    sc_options_add_switch(opt, opt_char, opt_name, variable, help_string)
+
+Add a switch option. This option is used without option arguments. Every use increments the variable by one. Its initial value is 0. Either opt\\_char or opt\\_name must be valid, that is, not '\\0'/NULL.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_switch (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, const char *help_string);
+```
+"""
+function sc_options_add_switch(opt, opt_char, opt_name, variable, help_string)
+    @ccall libsc.sc_options_add_switch(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_bool(opt, opt_char, opt_name, variable, init_value, help_string)
+
+Add a boolean option. It can be initialized to true or false in the C sense. Specifying it on the command line without argument sets the option to true. The argument 0/f/F/n/N sets it to false (0). The argument 1/t/T/y/Y sets it to true (nonzero).
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `init_value`:\\[in\\] Initial value to set the option, read as true or false.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_bool (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, int init_value, const char *help_string);
+```
+"""
+function sc_options_add_bool(opt, opt_char, opt_name, variable, init_value, help_string)
+    @ccall libsc.sc_options_add_bool(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, init_value::Cint, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_int(opt, opt_char, opt_name, variable, init_value, help_string)
+
+Add an option that takes an integer argument.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `init_value`:\\[in\\] The initial value of the option variable.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_int (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, int init_value, const char *help_string);
+```
+"""
+function sc_options_add_int(opt, opt_char, opt_name, variable, init_value, help_string)
+    @ccall libsc.sc_options_add_int(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, init_value::Cint, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_size_t(opt, opt_char, opt_name, variable, init_value, help_string)
+
+Add an option that takes a size\\_t argument. The value of the size\\_t variable must not be greater than LLONG\\_MAX.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `init_value`:\\[in\\] The initial value of the option variable.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_size_t (sc_options_t * opt, int opt_char, const char *opt_name, size_t *variable, size_t init_value, const char *help_string);
+```
+"""
+function sc_options_add_size_t(opt, opt_char, opt_name, variable, init_value, help_string)
+    @ccall libsc.sc_options_add_size_t(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Csize_t}, init_value::Csize_t, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_double(opt, opt_char, opt_name, variable, init_value, help_string)
+
+Add an option that takes a double argument. The double must be in the legal range. "inf" and "nan" are legal too.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `init_value`:\\[in\\] The initial value of the option variable.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_double (sc_options_t * opt, int opt_char, const char *opt_name, double *variable, double init_value, const char *help_string);
+```
+"""
+function sc_options_add_double(opt, opt_char, opt_name, variable, init_value, help_string)
+    @ccall libsc.sc_options_add_double(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cdouble}, init_value::Cdouble, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_string(opt, opt_char, opt_name, variable, init_value, help_string)
+
+Add a string option.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `variable`:\\[in\\] Address of the variable to store the option value.
+* `init_value`:\\[in\\] This default value of the option may be NULL. If not NULL, the value is copied to internal storage.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_string (sc_options_t * opt, int opt_char, const char *opt_name, const char **variable, const char *init_value, const char *help_string);
+```
+"""
+function sc_options_add_string(opt, opt_char, opt_name, variable, init_value, help_string)
+    @ccall libsc.sc_options_add_string(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cstring}, init_value::Cstring, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_inifile(opt, opt_char, opt_name, help_string)
+
+Add an option to read in a file in `.ini` format. The argument to this option must be a filename. On parsing the specified file is read to set known option variables. It does not have an associated option variable itself.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_inifile (sc_options_t * opt, int opt_char, const char *opt_name, const char *help_string);
+```
+"""
+function sc_options_add_inifile(opt, opt_char, opt_name, help_string)
+    @ccall libsc.sc_options_add_inifile(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_jsonfile(opt, opt_char, opt_name, help_string)
+
+Add an option to read in a file in JSON format. The argument to this option must be a filename. On parsing the specified file is read to set known option variables. It does not have an associated option variable itself.
+
+This functionality is only active when sc_have_json returns true, equivalent to the define SC\\_HAVE\\_JSON existing, and ignored otherwise.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_jsonfile (sc_options_t * opt, int opt_char, const char *opt_name, const char *help_string);
+```
+"""
+function sc_options_add_jsonfile(opt, opt_char, opt_name, help_string)
+    @ccall libsc.sc_options_add_jsonfile(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_callback(opt, opt_char, opt_name, has_arg, fn, data, help_string)
+
+Add an option that calls a user-defined function when parsed. The callback function should be implemented to allow multiple calls. The callback may be used to set multiple option variables in bulk that would otherwise require an inconvenient number of individual options. This option is not loaded from or saved to files.
+
+# Arguments
+* `opt`:\\[in,out\\] A valid options structure.
+* `opt_char`:\\[in\\] Short option character, may be '\\0'.
+* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
+* `has_arg`:\\[in\\] Specify whether the option needs an option argument. This can be 0 for none, 1 for a required argument, and 2 for an optional argument; see getopt\\_long (3).
+* `fn`:\\[in\\] Function to call when this option is encountered.
+* `data`:\\[in\\] User-defined data passed to the callback.
+* `help_string`:\\[in\\] Help string for usage message, may be NULL.
+### Prototype
+```c
+void sc_options_add_callback (sc_options_t * opt, int opt_char, const char *opt_name, int has_arg, sc_options_callback_t fn, void *data, const char *help_string);
+```
+"""
+function sc_options_add_callback(opt, opt_char, opt_name, has_arg, fn, data, help_string)
+    @ccall libsc.sc_options_add_callback(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, has_arg::Cint, fn::sc_options_callback_t, data::Ptr{Cvoid}, help_string::Cstring)::Cvoid
+end
+
+"""
+    sc_options_add_keyvalue(opt, opt_char, opt_name, variable, init_value, keyvalue, help_string)
+
+Add an option that takes string keys into a lookup table of integers. On calling this function, it must be certain that the initial value exists.
+
+# Arguments
+* `opt`:\\[in\\] Initialized options structure.
+* `opt_char`:\\[in\\] Option character for command line, or 0.
+* `opt_name`:\\[in\\] Name of the long option, or NULL.
+* `variable`:\\[in\\] Address of an existing integer that holds the value of this option parameter.
+* `init_value`:\\[in\\] The key that is looked up for the initial value. It must be certain that the key exists and its value is of type integer.
+* `keyvalue`:\\[in\\] A valid key-value structure where the values must be integers. If a key is asked for that does not exist, we will produce an option error. This structure must stay alive as long as opt.
+* `help_string`:\\[in\\] Instructive one-line string to explain the option.
+### Prototype
+```c
+```
+"""
+function sc_options_add_keyvalue(opt, opt_char, opt_name, variable, init_value, keyvalue, help_string)
+end
+
+"""
+    sc_options_add_suboptions(opt, subopt, prefix)
+
+Copy one set of options to another as a subset, with a prefix. The variables referenced by the options and the suboptions are the same.
+
+# Arguments
+* `opt`:\\[in,out\\] A set of options.
+* `subopt`:\\[in\\] Another set of options to be copied.
+* `prefix`:\\[in\\] The prefix to add to option names as they are copied. If an option has a long name "name" in subopt, its name in opt is "prefix:name"; if an option only has a character 'c' in subopt, its name in opt is "prefix:-c".
+### Prototype
+```c
+void sc_options_add_suboptions (sc_options_t * opt, sc_options_t * subopt, const char *prefix);
+```
+"""
+function sc_options_add_suboptions(opt, subopt, prefix)
+    @ccall libsc.sc_options_add_suboptions(opt::Ptr{sc_options_t}, subopt::Ptr{sc_options_t}, prefix::Cstring)::Cvoid
+end
+
+"""
+    sc_options_print_usage(package_id, log_priority, opt, arg_usage)
+
+Print a usage message. This function uses the `SC_LC_GLOBAL` log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `log_priority`:\\[in\\] Priority for output according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `arg_usage`:\\[in\\] If not NULL, an <ARGUMENTS> string is appended to the usage line. If the string is non-empty, it will be printed after the option summary and an "ARGUMENTS:\\n" title line. Line breaks are identified by strtok(3) and honored.
+### Prototype
+```c
+void sc_options_print_usage (int package_id, int log_priority, sc_options_t * opt, const char *arg_usage);
+```
+"""
+function sc_options_print_usage(package_id, log_priority, opt, arg_usage)
+    @ccall libsc.sc_options_print_usage(package_id::Cint, log_priority::Cint, opt::Ptr{sc_options_t}, arg_usage::Cstring)::Cvoid
+end
+
+"""
+    sc_options_print_summary(package_id, log_priority, opt)
+
+Print a summary of all option values. Prints the title "Options:" and a line for every option, then the title "Arguments:" and a line for every argument. This function uses the `SC_LC_GLOBAL` log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `log_priority`:\\[in\\] Priority for output according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+### Prototype
+```c
+void sc_options_print_summary (int package_id, int log_priority, sc_options_t * opt);
+```
+"""
+function sc_options_print_summary(package_id, log_priority, opt)
+    @ccall libsc.sc_options_print_summary(package_id::Cint, log_priority::Cint, opt::Ptr{sc_options_t})::Cvoid
+end
+
+"""
+    sc_options_load(package_id, err_priority, opt, file)
+
+Load a file in the default format and update option values. The default is a file in the `.ini` format; see sc_options_load_ini.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `file`:\\[in\\] Filename of the file to load.
+# Returns
+Returns 0 on success, -1 on failure.
+### Prototype
+```c
+int sc_options_load (int package_id, int err_priority, sc_options_t * opt, const char *file);
+```
+"""
+function sc_options_load(package_id, err_priority, opt, file)
+    @ccall libsc.sc_options_load(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, file::Cstring)::Cint
+end
+
+"""
+    sc_options_load_ini(package_id, err_priority, opt, inifile, re)
+
+Load a file in `.ini` format and update entries found under [Options]. An option whose name contains a colon such as "prefix:basename" will be updated by a "basename =" entry in a [prefix] section.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `inifile`:\\[in\\] Filename of the ini file to load.
+* `re`:\\[in,out\\] Provisioned for runtime error checking implementation; currently must be NULL.
+# Returns
+Returns 0 on success, -1 on failure.
+### Prototype
+```c
+int sc_options_load_ini (int package_id, int err_priority, sc_options_t * opt, const char *inifile, void *re);
+```
+"""
+function sc_options_load_ini(package_id, err_priority, opt, inifile, re)
+    @ccall libsc.sc_options_load_ini(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring, re::Ptr{Cvoid})::Cint
+end
+
+"""
+    sc_options_load_json(package_id, err_priority, opt, jsonfile, re)
+
+Load a file in JSON format and update entries from object "Options". An option whose name contains a colon such as "Prefix:basename" will be updated by a "basename :" entry in a "Prefix" nested object.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `jsonfile`:\\[in\\] Filename of the JSON file to load.
+* `re`:\\[in,out\\] Provisioned for runtime error checking implementation; currently must be NULL.
+# Returns
+Returns 0 on success, -1 on failure.
+### Prototype
+```c
+int sc_options_load_json (int package_id, int err_priority, sc_options_t * opt, const char *jsonfile, void *re);
+```
+"""
+function sc_options_load_json(package_id, err_priority, opt, jsonfile, re)
+    @ccall libsc.sc_options_load_json(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, jsonfile::Cstring, re::Ptr{Cvoid})::Cint
+end
+
+"""
+    sc_options_save(package_id, err_priority, opt, inifile)
+
+Save all options and arguments to a file in `.ini` format. This function must only be called after successful option parsing. This function should only be called on rank 0. This function will log errors with category `SC_LC_GLOBAL`. An options whose name contains a colon such as "Prefix:basename" will be written in a section titled [Prefix] as "basename =".
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `inifile`:\\[in\\] Filename of the ini file to save.
+# Returns
+Returns 0 on success, -1 on failure.
+### Prototype
+```c
+int sc_options_save (int package_id, int err_priority, sc_options_t * opt, const char *inifile);
+```
+"""
+function sc_options_save(package_id, err_priority, opt, inifile)
+    @ccall libsc.sc_options_save(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring)::Cint
+end
+
+"""
+    sc_options_load_args(package_id, err_priority, opt, inifile)
+
+Load a file in `.ini` format and update entries found under [Arguments]. There needs to be a key Arguments.count specifying the number. Then as many integer keys starting with 0 need to be present.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The args are stored in this option structure.
+* `inifile`:\\[in\\] Filename of the ini file to load.
+# Returns
+Returns 0 on success, -1 on failure.
+### Prototype
+```c
+int sc_options_load_args (int package_id, int err_priority, sc_options_t * opt, const char *inifile);
+```
+"""
+function sc_options_load_args(package_id, err_priority, opt, inifile)
+    @ccall libsc.sc_options_load_args(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring)::Cint
+end
+
+"""
+    sc_options_parse(package_id, err_priority, opt, argc, argv)
+
+Parse command line options.
+
+# Arguments
+* `package_id`:\\[in\\] Registered package id or -1.
+* `err_priority`:\\[in\\] Error priority according to sc_logprios.
+* `opt`:\\[in\\] The option structure.
+* `argc`:\\[in\\] Length of argument list.
+* `argv`:\\[in,out\\] Argument list may be permuted.
+# Returns
+Returns -1 on an invalid option, otherwise the position of the first non-option argument.
+### Prototype
+```c
+int sc_options_parse (int package_id, int err_priority, sc_options_t * opt, int argc, char **argv);
+```
+"""
+function sc_options_parse(package_id, err_priority, opt, argc, argv)
+    @ccall libsc.sc_options_parse(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, argc::Cint, argv::Ptr{Cstring})::Cint
+end
+
+"""
+    t8_cmesh_from_tetgen_file(fileprefix, partition, comm, do_dup)
+
+### Prototype
+```c
+t8_cmesh_t t8_cmesh_from_tetgen_file (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup);
+```
+"""
+function t8_cmesh_from_tetgen_file(fileprefix, partition, comm, do_dup)
+    @ccall libt8.t8_cmesh_from_tetgen_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint)::t8_cmesh_t
+end
+
+"""
+    t8_cmesh_from_tetgen_file_time(fileprefix, partition, comm, do_dup, fi, snapshot, stats, statentry)
+
+### Prototype
+```c
+t8_cmesh_t t8_cmesh_from_tetgen_file_time (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup, sc_flopinfo_t *fi, sc_flopinfo_t *snapshot, sc_statinfo_t *stats, int statentry);
+```
+"""
+function t8_cmesh_from_tetgen_file_time(fileprefix, partition, comm, do_dup, fi, snapshot, stats, statentry)
+    @ccall libt8.t8_cmesh_from_tetgen_file_time(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint, fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t}, stats::Ptr{sc_statinfo_t}, statentry::Cint)::t8_cmesh_t
+end
+
+"""
+    t8_cmesh_from_triangle_file(fileprefix, partition, comm, do_dup)
+
+### Prototype
+```c
+t8_cmesh_t t8_cmesh_from_triangle_file (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup);
+```
+"""
+function t8_cmesh_from_triangle_file(fileprefix, partition, comm, do_dup)
+    @ccall libt8.t8_cmesh_from_triangle_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint)::t8_cmesh_t
+end
+
+"""
+    t8_eclass_count_boundary(theclass, min_dim, per_eclass)
+
+Query the element class and count of boundary points.
+
+# Arguments
+* `theclass`:\\[in\\] We query a point of this element class.
+* `min_dim`:\\[in\\] Ignore boundary points of lesser dimension. The ignored points get a count value of 0.
+* `per_eclass`:\\[out\\] Array of length T8\\_ECLASS\\_COUNT to be filled with the count of the boundary objects, counted per each of the element classes.
+# Returns
+The count over all boundary points.
+### Prototype
+```c
+int t8_eclass_count_boundary (t8_eclass_t theclass, int min_dim, int *per_eclass);
+```
+"""
+function t8_eclass_count_boundary(theclass, min_dim, per_eclass)
+    @ccall libt8.t8_eclass_count_boundary(theclass::t8_eclass_t, min_dim::Cint, per_eclass::Ptr{Cint})::Cint
+end
+
+"""
+    t8_eclass_compare(eclass1, eclass2)
+
+Compare two eclasses of the same dimension as necessary for face neighbor orientation. The implemented order is Triangle < Square in 2D and Tet < Hex < Prism < Pyramid in 3D.
+
+# Arguments
+* `eclass1`:\\[in\\] The first eclass to compare.
+* `eclass2`:\\[in\\] The second eclass to compare.
+# Returns
+0 if the eclasses are equal, 1 if eclass1 > eclass2 and -1 if eclass1 < eclass2
+### Prototype
+```c
+int t8_eclass_compare (t8_eclass_t eclass1, t8_eclass_t eclass2);
+```
+"""
+function t8_eclass_compare(eclass1, eclass2)
+    @ccall libt8.t8_eclass_compare(eclass1::t8_eclass_t, eclass2::t8_eclass_t)::Cint
+end
+
+"""
+    t8_eclass_is_valid(eclass)
+
+Check whether a class is a valid class. Returns non-zero if it is a valid class, returns zero, if the class is equal to T8\\_ECLASS\\_INVALID.
+
+# Arguments
+* `eclass`:\\[in\\] The eclass to check.
+# Returns
+Non-zero if *eclass* is valid, zero otherwise.
+### Prototype
+```c
+int t8_eclass_is_valid (t8_eclass_t eclass);
+```
+"""
+function t8_eclass_is_valid(eclass)
+    @ccall libt8.t8_eclass_is_valid(eclass::t8_eclass_t)::Cint
+end
+
+mutable struct t8_element end
+
+"""Opaque structure for a generic element, only used as pointer. Implementations are free to cast it to their internal data structure."""
+const t8_element_t = t8_element
+
+"""
+    t8_scheme_cxx_ref(scheme)
+
+Increase the reference counter of a scheme.
+
+# Arguments
+* `scheme`:\\[in,out\\] On input, this scheme must be alive, that is, exist with positive reference count.
+### Prototype
+```c
+void t8_scheme_cxx_ref (t8_scheme_cxx_t *scheme);
+```
+"""
+function t8_scheme_cxx_ref(scheme)
+    @ccall libt8.t8_scheme_cxx_ref(scheme::Ptr{t8_scheme_cxx_t})::Cvoid
+end
+
+"""
+    t8_scheme_cxx_unref(pscheme)
+
+Decrease the reference counter of a scheme. If the counter reaches zero, this scheme is destroyed.
+
+# Arguments
+* `pscheme`:\\[in,out\\] On input, the scheme pointed to must exist with positive reference count. If the reference count reaches zero, the scheme is destroyed and this pointer set to NULL. Otherwise, the pointer is not changed and the scheme is not modified in other ways.
+### Prototype
+```c
+void t8_scheme_cxx_unref (t8_scheme_cxx_t **pscheme);
+```
+"""
+function t8_scheme_cxx_unref(pscheme)
+    @ccall libt8.t8_scheme_cxx_unref(pscheme::Ptr{Ptr{t8_scheme_cxx_t}})::Cvoid
+end
+
+"""
+    t8_scheme_cxx_destroy(s)
+
+### Prototype
+```c
+extern void t8_scheme_cxx_destroy (t8_scheme_cxx_t *s);
+```
+"""
+function t8_scheme_cxx_destroy(s)
+    @ccall libt8.t8_scheme_cxx_destroy(s::Ptr{t8_scheme_cxx_t})::Cvoid
+end
+
+"""
+    t8_element_size(ts)
+
+Return the size of any element of a given class.
+
+# Returns
+The size of an element of class **ts**. We provide a default implementation of this routine that should suffice for most use cases.
+### Prototype
+```c
+size_t t8_element_size (const t8_eclass_scheme_c *ts);
+```
+"""
+function t8_element_size(ts)
+    @ccall libt8.t8_element_size(ts::Ptr{t8_eclass_scheme_c})::Csize_t
+end
+
+"""
+    t8_element_refines_irregular(ts)
+
+Returns true, if there is one element in the tree, that does not refine into 2^dim children. Returns false otherwise.
+
+### Prototype
+```c
+int t8_element_refines_irregular (const t8_eclass_scheme_c *ts);
+```
+"""
+function t8_element_refines_irregular(ts)
+    @ccall libt8.t8_element_refines_irregular(ts::Ptr{t8_eclass_scheme_c})::Cint
+end
+
+"""
+    t8_element_maxlevel(ts)
+
+Return the maximum allowed level for any element of a given class.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+# Returns
+The maximum allowed level for elements of class **ts**.
+### Prototype
+```c
+int t8_element_maxlevel (const t8_eclass_scheme_c *ts);
+```
+"""
+function t8_element_maxlevel(ts)
+    @ccall libt8.t8_element_maxlevel(ts::Ptr{t8_eclass_scheme_c})::Cint
+end
+
+"""
+    t8_element_level(ts, elem)
+
+### Prototype
+```c
+int t8_element_level (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_level(ts, elem)
+    @ccall libt8.t8_element_level(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_copy(ts, source, dest)
+
+Copy all entries of **source** to **dest**. **dest** must be an existing element. No memory is allocated by this function.
+
+!!! note
+
+    *source* and *dest* may point to the same element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `source`:\\[in\\] The element whose entries will be copied to **dest**.
+* `dest`:\\[in,out\\] This element's entries will be overwritten with the entries of **source**.
+### Prototype
+```c
+void t8_element_copy (const t8_eclass_scheme_c *ts, const t8_element_t *source, t8_element_t *dest);
+```
+"""
+function t8_element_copy(ts, source, dest)
+    @ccall libt8.t8_element_copy(ts::Ptr{t8_eclass_scheme_c}, source::Ptr{t8_element_t}, dest::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_compare(ts, elem1, elem2)
+
+Compare two elements with respect to the scheme.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem1`:\\[in\\] The first element.
+* `elem2`:\\[in\\] The second element.
+# Returns
+negative if elem1 < elem2, zero if elem1 equals elem2 and positive if elem1 > elem2. If elem2 is a copy of elem1 then the elements are equal.
+### Prototype
+```c
+int t8_element_compare (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2);
+```
+"""
+function t8_element_compare(ts, elem1, elem2)
+    @ccall libt8.t8_element_compare(ts::Ptr{t8_eclass_scheme_c}, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_equal(ts, elem1, elem2)
+
+Check if two elements are equal.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem1`:\\[in\\] The first element.
+* `elem2`:\\[in\\] The second element.
+# Returns
+1 if the elements are equal, 0 if they are not equal
+### Prototype
+```c
+int t8_element_equal (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2);
+```
+"""
+function t8_element_equal(ts, elem1, elem2)
+    @ccall libt8.t8_element_equal(ts::Ptr{t8_eclass_scheme_c}, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_parent(ts, elem, parent)
+
+Compute the parent of a given element **elem** and store it in **parent**. **parent** needs to be an existing element. No memory is allocated by this function. **elem** and **parent** can point to the same element, then the entries of **elem** are overwritten by the ones of its parent.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element whose parent will be computed.
+* `parent`:\\[in,out\\] This element's entries will be overwritten by those of **elem**'s parent. The storage for this element must exist and match the element class of the parent.
+### Prototype
+```c
+void t8_element_parent (const t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_element_t *parent);
+```
+"""
+function t8_element_parent(ts, elem, parent)
+    @ccall libt8.t8_element_parent(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, parent::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_num_siblings(ts, elem)
+
+Compute the number of siblings of an element. That is the number of  Children of its parent.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+# Returns
+The number of siblings of *element*. Note that this number is >= 1, since we count the element itself as a sibling.
+### Prototype
+```c
+int t8_element_num_siblings (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_num_siblings(ts, elem)
+    @ccall libt8.t8_element_num_siblings(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_sibling(ts, elem, sibid, sibling)
+
+Compute a specific sibling of a given element **elem** and store it in **sibling**. **sibling** needs to be an existing element. No memory is allocated by this function. **elem** and **sibling** can point to the same element, then the entries of **elem** are overwritten by the ones of its i-th sibling.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element whose sibling will be computed.
+* `sibid`:\\[in\\] The id of the sibling computed.
+* `sibling`:\\[in,out\\] This element's entries will be overwritten by those of **elem**'s sibid-th sibling. The storage for this element must exist and match the element class of the sibling.
+### Prototype
+```c
+void t8_element_sibling (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int sibid, t8_element_t *sibling);
+```
+"""
+function t8_element_sibling(ts, elem, sibid, sibling)
+    @ccall libt8.t8_element_sibling(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, sibid::Cint, sibling::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_num_corners(ts, elem)
+
+Compute the number of corners of an element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+# Returns
+The number of corners of *element*.
+### Prototype
+```c
+int t8_element_num_corners (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_num_corners(ts, elem)
+    @ccall libt8.t8_element_num_corners(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_num_faces(ts, elem)
+
+Compute the number of faces of an element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+# Returns
+The number of faces of *element*.
+### Prototype
+```c
+int t8_element_num_faces (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_num_faces(ts, elem)
+    @ccall libt8.t8_element_num_faces(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_max_num_faces(ts, elem)
+
+Compute the maximum number of faces of a given element and all of its descendants.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+# Returns
+The number of faces of *element*.
+### Prototype
+```c
+int t8_element_max_num_faces (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_max_num_faces(ts, elem)
+    @ccall libt8.t8_element_max_num_faces(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_num_children(ts, elem)
+
+Compute the number of children of an element when it is refined.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+# Returns
+The number of children of *element*.
+### Prototype
+```c
+int t8_element_num_children (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_num_children(ts, elem)
+    @ccall libt8.t8_element_num_children(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_num_face_children(ts, elem, face)
+
+Compute the number of children of an element's face when the element is refined.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] A face of *elem*.
+# Returns
+The number of children of *face* if *elem* is to be refined.
+### Prototype
+```c
+int t8_element_num_face_children (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face);
+```
+"""
+function t8_element_num_face_children(ts, elem, face)
+    @ccall libt8.t8_element_num_face_children(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint)::Cint
+end
+
+"""
+    t8_element_get_face_corner(ts, elem, face, corner)
+
+Return the corner number of an element's face corner. Example quad: 2 x --- x 3 | | | | face 1 0 x --- x 1 Thus for face = 1 the output is: corner=0 : 1, corner=1: 3
+
+The order in which the corners must be given is determined by the eclass of *element*: LINE/QUAD/TRIANGLE: No specific order. HEX : In Z-order of the face starting with the lowest corner number. TET : Starting with the lowest corner number counterclockwise as seen from 'outside' of the element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `element`:\\[in\\] The element.
+* `face`:\\[in\\] A face index for *element*.
+* `corner`:\\[in\\] A corner index for the face 0 <= *corner* < num\\_face\\_corners.
+# Returns
+The corner number of the *corner*-th vertex of *face*.
+### Prototype
+```c
+int t8_element_get_face_corner (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, int corner);
+```
+"""
+function t8_element_get_face_corner(ts, elem, face, corner)
+    @ccall libt8.t8_element_get_face_corner(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, corner::Cint)::Cint
+end
+
+"""
+    t8_element_get_corner_face(ts, elem, corner, face)
+
+Compute the face numbers of the faces sharing an element's corner. Example quad: 2 x --- x 3 | | | | face 1 0 x --- x 1 face 2 Thus for corner = 1 the output is: face=0 : 2, face=1: 1
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `element`:\\[in\\] The element.
+* `corner`:\\[in\\] A corner index for the face.
+* `face`:\\[in\\] A face index for *corner*.
+# Returns
+The face number of the *face*-th face at *corner*.
+### Prototype
+```c
+int t8_element_get_corner_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int corner, int face);
+```
+"""
+function t8_element_get_corner_face(ts, elem, corner, face)
+    @ccall libt8.t8_element_get_corner_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, corner::Cint, face::Cint)::Cint
+end
+
+"""
+    t8_element_child(ts, elem, childid, child)
+
+Construct the child element of a given number.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] This must be a valid element, bigger than maxlevel.
+* `childid`:\\[in\\] The number of the child to construct.
+* `child`:\\[in,out\\] The storage for this element must exist. On output, a valid element. It is valid to call this function with elem = child.
+### Prototype
+```c
+void t8_element_child (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int childid, t8_element_t *child);
+```
+"""
+function t8_element_child(ts, elem, childid, child)
+    @ccall libt8.t8_element_child(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, childid::Cint, child::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_children(ts, elem, length, c)
+
+Construct all children of a given element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] This must be a valid element, bigger than maxlevel.
+* `length`:\\[in\\] The length of the output array *c* must match the number of children.
+* `c`:\\[in,out\\] The storage for these *length* elements must exist and match the element class in the children's ordering. On output, all children are valid. It is valid to call this function with elem = c[0].
+# See also
+[`t8_element_num_children`](@ref)
+
+### Prototype
+```c
+void t8_element_children (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int length, t8_element_t *c[]);
+```
+"""
+function t8_element_children(ts, elem, length, c)
+    @ccall libt8.t8_element_children(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, length::Cint, c::Ptr{Ptr{t8_element_t}})::Cvoid
+end
+
+"""
+    t8_element_child_id(ts, elem)
+
+Compute the child id of an element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] This must be a valid element.
+# Returns
+The child id of elem.
+### Prototype
+```c
+int t8_element_child_id (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_child_id(ts, elem)
+    @ccall libt8.t8_element_child_id(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cint
+end
+
+"""
+    t8_element_ancestor_id(ts, elem, level)
+
+Compute the ancestor id of an element, that is the child id at a given level.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] This must be a valid element.
+* `level`:\\[in\\] A refinement level. Must satisfy *level* < elem.level
+# Returns
+The child\\_id of *elem* in regard to its *level* ancestor.
+### Prototype
+```c
+int t8_element_ancestor_id (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int level);
+```
+"""
+function t8_element_ancestor_id(ts, elem, level)
+    @ccall libt8.t8_element_ancestor_id(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, level::Cint)::Cint
+end
+
+"""
+    t8_element_is_family(ts, fam)
+
+Query whether a given set of elements is a family or not.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `fam`:\\[in\\] An array of as many elements as an element of class **ts** has children.
+# Returns
+Zero if **fam** is not a family, nonzero if it is.
+### Prototype
+```c
+int t8_element_is_family (const t8_eclass_scheme_c *ts, t8_element_t *const *fam);
+```
+"""
+function t8_element_is_family(ts, fam)
+    @ccall libt8.t8_element_is_family(ts::Ptr{t8_eclass_scheme_c}, fam::Ptr{Ptr{t8_element_t}})::Cint
+end
+
+"""
+    t8_element_nca(ts, elem1, elem2, nca)
+
+Compute the nearest common ancestor of two elements. That is, the element with highest level that still has both given elements as descendants.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem1`:\\[in\\] The first of the two input elements.
+* `elem2`:\\[in\\] The second of the two input elements.
+* `nca`:\\[in,out\\] The storage for this element must exist and match the element class of the child. On output the unique nearest common ancestor of **elem1** and **elem2**.
+### Prototype
+```c
+void t8_element_nca (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2, t8_element_t *nca);
+```
+"""
+function t8_element_nca(ts, elem1, elem2, nca)
+    @ccall libt8.t8_element_nca(ts::Ptr{t8_eclass_scheme_c}, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t}, nca::Ptr{t8_element_t})::Cvoid
+end
+
+"""Type definition for the geometric shape of an element. Currently the possible shapes are the same as the possible element classes. I.e. T8\\_ECLASS\\_VERTEX, T8\\_ECLASS\\_TET, etc..."""
+const t8_element_shape_t = t8_eclass_t
+
+"""
+    t8_element_face_shape(ts, elem, face)
+
+Compute the shape of the face of an element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] A face of *elem*.
+# Returns
+The element shape of the face. I.e. T8\\_ECLASS\\_LINE for quads, T8\\_ECLASS\\_TRIANGLE for tets and depending on the face number either T8\\_ECLASS\\_QUAD or T8\\_ECLASS\\_TRIANGLE for prisms.
+### Prototype
+```c
+t8_element_shape_t t8_element_face_shape (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face);
+```
+"""
+function t8_element_face_shape(ts, elem, face)
+    @ccall libt8.t8_element_face_shape(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint)::t8_element_shape_t
+end
+
+"""
+    t8_element_children_at_face(ts, elem, face, children, num_children, child_indices)
+
+Given an element and a face of the element, compute all children of the element that touch the face.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] A face of *elem*.
+* `children`:\\[in,out\\] Allocated elements, in which the children of *elem* that share a face with *face* are stored. They will be stored in order of their linear id.
+* `num_children`:\\[in\\] The number of elements in *children*. Must match the number of children that touch *face*. t8_element_num_face_children
+* `child_indices`:\\[in,out\\] If not NULL, an array of num\\_children integers must be given, on output its i-th entry is the child\\_id of the i-th face\\_child. It is valid to call this function with elem = children[0].
+### Prototype
+```c
+void t8_element_children_at_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, t8_element_t *children[], int num_children, int *child_indices);
+```
+"""
+function t8_element_children_at_face(ts, elem, face, children, num_children, child_indices)
+    @ccall libt8.t8_element_children_at_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, children::Ptr{Ptr{t8_element_t}}, num_children::Cint, child_indices::Ptr{Cint})::Cvoid
+end
+
+"""
+    t8_element_face_child_face(ts, elem, face, face_child)
+
+Given a face of an element and a child number of a child of that face, return the face number of the child of the element that matches the child face.
+
+```c++
+  x ---- x   x      x           x ---- x
+  |      |   |      |           |   |  | <-- f
+  |      |   |      x           |   x--x
+  |      |   |                  |      |
+  x ---- x   x                  x ---- x
+   elem    face  face_child    Returns the face number f
+```
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] Then number of the face.
+* `face_child`:\\[in\\] A number 0 <= *face_child* < num\\_face\\_children, specifying a child of *elem* that shares a face with *face*. These children are counted in linear order. This coincides with the order of children from a call to t8_element_children_at_face.
+# Returns
+The face number of the face of a child of *elem* that coincides with *face_child*.
+### Prototype
+```c
+int t8_element_face_child_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, int face_child);
+```
+"""
+function t8_element_face_child_face(ts, elem, face, face_child)
+    @ccall libt8.t8_element_face_child_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, face_child::Cint)::Cint
+end
+
+"""
+    t8_element_face_parent_face(ts, elem, face)
+
+Given a face of an element return the face number of the parent of the element that matches the element's face. Or return -1 if no face of the parent matches the face.
+
+!!! note
+
+    For the root element this function always returns *face*.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] Then number of the face.
+# Returns
+If *face* of *elem* is also a face of *elem*'s parent, the face number of this face. Otherwise -1.
+### Prototype
+```c
+int t8_element_face_parent_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face);
+```
+"""
+function t8_element_face_parent_face(ts, elem, face)
+    @ccall libt8.t8_element_face_parent_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint)::Cint
+end
+
+"""
+    t8_element_tree_face(ts, elem, face)
+
+Given an element and a face of this element. If the face lies on the tree boundary, return the face number of the tree face. If not the return value is arbitrary.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element.
+* `face`:\\[in\\] The index of a face of *elem*.
+# Returns
+The index of the tree face that *face* is a subface of, if *face* is on a tree boundary. Any arbitrary integer if *is* not at a tree boundary.
+### Prototype
+```c
+int t8_element_tree_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face);
+```
+"""
+function t8_element_tree_face(ts, elem, face)
+    @ccall libt8.t8_element_tree_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint)::Cint
+end
+
+"""
+    t8_element_transform_face(ts, elem1, elem2, orientation, sign, is_smaller_face)
+
+Suppose we have two trees that share a common face f. Given an element e that is a subface of f in one of the trees and given the orientation of the tree connection, construct the face element of the respective tree neighbor that logically coincides with e but lies in the coordinate system of the neighbor tree.
+
+!!! note
+
+    *elem1* and *elem2* may point to the same element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem1`:\\[in\\] The face element.
+* `elem2`:\\[in,out\\] On return the face element *elem1* with respect to the coordinate system of the other tree.
+* `orientation`:\\[in\\] The orientation of the tree-tree connection.
+* `sign`:\\[in\\] Depending on the topological orientation of the two tree faces, either 0 (both faces have opposite orientation) or 1 (both faces have the same top. orientattion). t8_eclass_face_orientation
+* `is_smaller_face`:\\[in\\] Flag to declare whether *elem1* belongs to the smaller face. A face f of tree T is smaller than f' of T' if either the eclass of T is smaller or if the classes are equal and f<f'. The orientation is defined in relation to the smaller face.
+# See also
+[`t8_cmesh_set_join`](@ref)
+
+### Prototype
+```c
+void t8_element_transform_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, t8_element_t *elem2, int orientation, int sign, int is_smaller_face);
+```
+"""
+function t8_element_transform_face(ts, elem1, elem2, orientation, sign, is_smaller_face)
+    @ccall libt8.t8_element_transform_face(ts::Ptr{t8_eclass_scheme_c}, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t}, orientation::Cint, sign::Cint, is_smaller_face::Cint)::Cvoid
+end
+
+"""
+    t8_element_extrude_face(ts, face, face_scheme, elem, root_face)
+
+Given a boundary face inside a root tree's face construct the element inside the root tree that has the given face as a face.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `face`:\\[in\\] A face element.
+* `face_scheme`:\\[in\\] The scheme for the face element.
+* `elem`:\\[in,out\\] An allocated element. The entries will be filled with the data of the element that has *face* as a face and lies within the root tree.
+* `root_face`:\\[in\\] The index of the face of the root tree in which *face* lies.
+# Returns
+The face number of the face of *elem* that coincides with *face*.
+### Prototype
+```c
+int t8_element_extrude_face (const t8_eclass_scheme_c *ts, const t8_element_t *face, const t8_eclass_scheme_c *face_scheme, t8_element_t *elem, int root_face);
+```
+"""
+function t8_element_extrude_face(ts, face, face_scheme, elem, root_face)
+    @ccall libt8.t8_element_extrude_face(ts::Ptr{t8_eclass_scheme_c}, face::Ptr{t8_element_t}, face_scheme::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, root_face::Cint)::Cint
+end
+
+"""
+    t8_element_boundary_face(ts, elem, face, boundary, boundary_scheme)
+
+Construct the boundary element at a specific face.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The input element.
+* `face`:\\[in\\] The index of the face of which to construct the boundary element.
+* `boundary`:\\[in,out\\] An allocated element of dimension of *element* minus 1. The entries will be filled with the entries of the face of *element*.
+* `boundary_scheme`:\\[in\\] The scheme for the eclass of the boundary face. If *elem* is of class T8\\_ECLASS\\_VERTEX, then *boundary* must be NULL and will not be modified.
+### Prototype
+```c
+void t8_element_boundary_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, t8_element_t *boundary, const t8_eclass_scheme_c *boundary_scheme);
+```
+"""
+function t8_element_boundary_face(ts, elem, face, boundary, boundary_scheme)
+    @ccall libt8.t8_element_boundary_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, boundary::Ptr{t8_element_t}, boundary_scheme::Ptr{t8_eclass_scheme_c})::Cvoid
+end
+
+"""
+    t8_element_first_descendant_face(ts, elem, face, first_desc, level)
+
+Construct the first descendant of an element at a given level that touches a given face.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The input element.
+* `face`:\\[in\\] A face of *elem*.
+* `first_desc`:\\[in,out\\] An allocated element. This element's data will be filled with the data of the first descendant of *elem* that shares a face with *face*.
+* `level`:\\[in\\] The level, at which the first descendant is constructed
+### Prototype
+```c
+void t8_element_first_descendant_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, t8_element_t *first_desc, int level);
+```
+"""
+function t8_element_first_descendant_face(ts, elem, face, first_desc, level)
+    @ccall libt8.t8_element_first_descendant_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, first_desc::Ptr{t8_element_t}, level::Cint)::Cvoid
+end
+
+"""
+    t8_element_last_descendant_face(ts, elem, face, last_desc, level)
+
+Construct the last descendant of an element at a given level that touches a given face.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The input element.
+* `face`:\\[in\\] A face of *elem*.
+* `last_desc`:\\[in,out\\] An allocated element. This element's data will be filled with the data of the last descendant of *elem* that shares a face with *face*.
+* `level`:\\[in\\] The level, at which the last descendant is constructed
+### Prototype
+```c
+void t8_element_last_descendant_face (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face, t8_element_t *last_desc, int level);
+```
+"""
+function t8_element_last_descendant_face(ts, elem, face, last_desc, level)
+    @ccall libt8.t8_element_last_descendant_face(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint, last_desc::Ptr{t8_element_t}, level::Cint)::Cvoid
+end
+
+"""
+    t8_element_is_root_boundary(ts, elem, face)
+
+Compute whether a given element shares a given face with its root tree.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The input element.
+* `face`:\\[in\\] A face of *elem*.
+# Returns
+True if *face* is a subface of the element's root element.
+### Prototype
+```c
+int t8_element_is_root_boundary (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int face);
+```
+"""
+function t8_element_is_root_boundary(ts, elem, face)
+    @ccall libt8.t8_element_is_root_boundary(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, face::Cint)::Cint
+end
+
+"""
+    t8_element_face_neighbor_inside(ts, elem, neigh, face, neigh_face)
+
+Construct the face neighbor of a given element if this face neighbor is inside the root tree. Return 0 otherwise.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element to be considered.
+* `neigh`:\\[in,out\\] If the face neighbor of *elem* along *face* is inside the root tree, this element's data is filled with the data of the face neighbor. Otherwise the data can be modified arbitrarily.
+* `face`:\\[in\\] The number of the face along which the neighbor should be constructed.
+* `neigh_face`:\\[out\\] The number of *face* as viewed from *neigh*. An arbitrary value, if the neighbor is not inside the root tree.
+# Returns
+True if *neigh* is inside the root tree. False if not. In this case *neigh*'s data can be arbitrary on output.
+### Prototype
+```c
+int t8_element_face_neighbor_inside (const t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_element_t *neigh, int face, int *neigh_face);
+```
+"""
+function t8_element_face_neighbor_inside(ts, elem, neigh, face, neigh_face)
+    @ccall libt8.t8_element_face_neighbor_inside(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, neigh::Ptr{t8_element_t}, face::Cint, neigh_face::Ptr{Cint})::Cint
+end
+
+"""
+    t8_element_shape(ts, elem)
+
+Return the shape of an allocated element according its type. For example, a child of an element can be an element of a different shape and has to be handled differently - according to its shape.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element to be considered
+# Returns
+The shape of the element as an eclass
+### Prototype
+```c
+t8_element_shape_t t8_element_shape (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+```
+"""
+function t8_element_shape(ts, elem)
+    @ccall libt8.t8_element_shape(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::t8_element_shape_t
+end
+
+"""
+    t8_element_set_linear_id(ts, elem, level, id)
+
+Initialize the entries of an allocated element according to a given linear id in a uniform refinement.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in,out\\] The element whose entries will be set.
+* `level`:\\[in\\] The level of the uniform refinement to consider.
+* `id`:\\[in\\] The linear id. id must fulfil 0 <= id < 'number of leaves in the uniform refinement'
+### Prototype
+```c
+void t8_element_set_linear_id (const t8_eclass_scheme_c *ts, t8_element_t *elem, int level, t8_linearidx_t id);
+```
+"""
+function t8_element_set_linear_id(ts, elem, level, id)
+    @ccall libt8.t8_element_set_linear_id(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, level::Cint, id::t8_linearidx_t)::Cvoid
+end
+
+"""
+    t8_element_get_linear_id(ts, elem, level)
+
+Compute the linear id of a given element in a hypothetical uniform refinement of a given level.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element whose id we compute.
+* `level`:\\[in\\] The level of the uniform refinement to consider.
+# Returns
+The linear id of the element.
+### Prototype
+```c
+t8_linearidx_t t8_element_get_linear_id (const t8_eclass_scheme_c *ts, const t8_element_t *elem, int level);
+```
+"""
+function t8_element_get_linear_id(ts, elem, level)
+    @ccall libt8.t8_element_get_linear_id(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, level::Cint)::t8_linearidx_t
+end
+
+"""
+    t8_element_first_descendant(ts, elem, desc, level)
+
+Compute the first descendant of a given element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element whose descendant is computed.
+* `desc`:\\[out\\] The first element in a uniform refinement of *elem* of the maximum possible level.
+### Prototype
+```c
+void t8_element_first_descendant (const t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_element_t *desc, int level);
+```
+"""
+function t8_element_first_descendant(ts, elem, desc, level)
+    @ccall libt8.t8_element_first_descendant(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, desc::Ptr{t8_element_t}, level::Cint)::Cvoid
+end
+
+"""
+    t8_element_last_descendant(ts, elem, desc, level)
+
+Compute the last descendant of a given element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in\\] The element whose descendant is computed.
+* `desc`:\\[out\\] The last element in a uniform refinement of *elem* of the maximum possible level.
+### Prototype
+```c
+void t8_element_last_descendant (const t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_element_t *desc, int level);
+```
+"""
+function t8_element_last_descendant(ts, elem, desc, level)
+    @ccall libt8.t8_element_last_descendant(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t}, desc::Ptr{t8_element_t}, level::Cint)::Cvoid
+end
+
+"""
+    t8_element_successor(ts, elem1, elem2)
+
+Construct the successor in a uniform refinement of a given element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem1`:\\[in\\] The element whose successor should be constructed.
+* `elem2`:\\[in,out\\] The element whose entries will be set.
+* `level`:\\[in\\] The level of the uniform refinement to consider.
+### Prototype
+```c
+void t8_element_successor (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, t8_element_t *elem2);
+```
+"""
+function t8_element_successor(ts, elem1, elem2)
+    @ccall libt8.t8_element_successor(ts::Ptr{t8_eclass_scheme_c}, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_vertex_reference_coords(ts, t, vertex, coords)
+
+Compute the coordinates of a given element vertex inside a reference tree that is embedded into [0,1]^d (d = dimension).
+
+!!! warning
+
+    coords should be zero-initialized, as only the first d coords will be set, but when used elsewhere all coords might be used.
+
+# Arguments
+* `t`:\\[in\\] The element to be considered.
+* `vertex`:\\[in\\] The id of the vertex whose coordinates shall be computed.
+* `coords`:\\[out\\] An array of at least as many doubles as the element's dimension whose entries will be filled with the coordinates of *vertex*.
+### Prototype
+```c
+void t8_element_vertex_reference_coords (const t8_eclass_scheme_c *ts, const t8_element_t *t, const int vertex, double coords[]);
+```
+"""
+function t8_element_vertex_reference_coords(ts, t, vertex, coords)
+    @ccall libt8.t8_element_vertex_reference_coords(ts::Ptr{t8_eclass_scheme_c}, t::Ptr{t8_element_t}, vertex::Cint, coords::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_element_count_leaves(ts, t, level)
+
+Count how many leaf descendants of a given uniform level an element would produce.
+
+Example: If *t* is a line element that refines into 2 line elements on each level, then the return value is max(0, 2^{*level* - level(*t*)}). Thus, if *t*'s level is 0, and *level* = 3, the return value is 2^3 = 8.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `t`:\\[in\\] The element to be checked.
+* `level`:\\[in\\] A refinement level.
+# Returns
+Suppose *t* is uniformly refined up to level *level*. The return value is the resulting number of elements (of the given level). If *level* < [`t8_element_level`](@ref)(t), the return value should be 0.
+### Prototype
+```c
+t8_gloidx_t t8_element_count_leaves (const t8_eclass_scheme_c *ts, const t8_element_t *t, int level);
+```
+"""
+function t8_element_count_leaves(ts, t, level)
+    @ccall libt8.t8_element_count_leaves(ts::Ptr{t8_eclass_scheme_c}, t::Ptr{t8_element_t}, level::Cint)::t8_gloidx_t
+end
+
+"""
+    t8_element_count_leaves_from_root(ts, level)
+
+Count how many leaf descendants of a given uniform level the root element will produce.
+
+This is a convenience function, and can be implemented via t8_element_count_leaves.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `level`:\\[in\\] A refinement level.
+# Returns
+The value of t8_element_count_leaves if the input element is the root (level 0) element.
+### Prototype
+```c
+t8_gloidx_t t8_element_count_leaves_from_root (const t8_eclass_scheme_c *ts, int level);
+```
+"""
+function t8_element_count_leaves_from_root(ts, level)
+    @ccall libt8.t8_element_count_leaves_from_root(ts::Ptr{t8_eclass_scheme_c}, level::Cint)::t8_gloidx_t
+end
+
+"""
+    t8_element_new(ts, length, elems)
+
+Allocate memory for an array of elements of a given class and initialize them.
+
+!!! note
+
+    Not every element that is created in t8code will be created by a call to this function. However, if an element is not created using t8_element_new, then it is guaranteed that t8_element_init is called on it.
+
+!!! note
+
+    In debugging mode, an element that was created with t8_element_new must pass t8_element_is_valid.
+
+!!! note
+
+    If an element was created by t8_element_new then t8_element_init may not be called for it. Thus, t8_element_new should initialize an element in the same way as a call to t8_element_init would.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `length`:\\[in\\] The number of elements to be allocated.
+* `elems`:\\[in,out\\] On input an array of **length** many unallocated element pointers. On output all these pointers will point to an allocated and initialized element.
+# See also
+t8\\_element\\_init, t8\\_element\\_is\\_valid
+
+### Prototype
+```c
+void t8_element_new (const t8_eclass_scheme_c *ts, int length, t8_element_t **elems);
+```
+"""
+function t8_element_new(ts, length, elems)
+    @ccall libt8.t8_element_new(ts::Ptr{t8_eclass_scheme_c}, length::Cint, elems::Ptr{Ptr{t8_element_t}})::Cvoid
+end
+
+"""
+    t8_element_destroy(ts, length, elems)
+
+Deallocate an array of elements.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `length`:\\[in\\] The number of elements in the array.
+* `elems`:\\[in,out\\] On input an array of **length** many allocated element pointers. On output all these pointers will be freed. **elem** itself will not be freed by this function.
+### Prototype
+```c
+void t8_element_destroy (const t8_eclass_scheme_c *ts, int length, t8_element_t **elems);
+```
+"""
+function t8_element_destroy(ts, length, elems)
+    @ccall libt8.t8_element_destroy(ts::Ptr{t8_eclass_scheme_c}, length::Cint, elems::Ptr{Ptr{t8_element_t}})::Cvoid
+end
+
+"""
+    t8_element_root(ts, elem)
+
+Fills an element with the root element.
+
+# Arguments
+* `ts`:\\[in\\] Implementation of a class scheme.
+* `elem`:\\[in,out\\] The element to be filled with root.
+### Prototype
+```c
+void t8_element_root (const t8_eclass_scheme_c *ts, t8_element_t *elem);
+```
+"""
+function t8_element_root(ts, elem)
+    @ccall libt8.t8_element_root(ts::Ptr{t8_eclass_scheme_c}, elem::Ptr{t8_element_t})::Cvoid
+end
+
+"""
+    t8_element_MPI_Pack(ts, elements, count, send_buffer, buffer_size, position, comm)
+
+### Prototype
+```c
+void t8_element_MPI_Pack (const t8_eclass_scheme_c *ts, t8_element_t **const elements, const unsigned int count, void *send_buffer, const int buffer_size, int *position, sc_MPI_Comm comm);
+```
+"""
+function t8_element_MPI_Pack(ts, elements, count, send_buffer, buffer_size, position, comm)
+    @ccall libt8.t8_element_MPI_Pack(ts::Ptr{t8_eclass_scheme_c}, elements::Ptr{Ptr{t8_element_t}}, count::Cuint, send_buffer::Ptr{Cvoid}, buffer_size::Cint, position::Ptr{Cint}, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_element_MPI_Pack_size(ts, count, comm, pack_size)
+
+### Prototype
+```c
+void t8_element_MPI_Pack_size (const t8_eclass_scheme_c *ts, const unsigned int count, sc_MPI_Comm comm, int *pack_size);
+```
+"""
+function t8_element_MPI_Pack_size(ts, count, comm, pack_size)
+    @ccall libt8.t8_element_MPI_Pack_size(ts::Ptr{t8_eclass_scheme_c}, count::Cuint, comm::MPI_Comm, pack_size::Ptr{Cint})::Cvoid
+end
+
+"""
+    t8_element_MPI_Unpack(ts, recvbuf, buffer_size, position, elements, count, comm)
+
+### Prototype
+```c
+void t8_element_MPI_Unpack (const t8_eclass_scheme_c *ts, void *recvbuf, const int buffer_size, int *position, t8_element_t **elements, const unsigned int count, sc_MPI_Comm comm);
+```
+"""
+function t8_element_MPI_Unpack(ts, recvbuf, buffer_size, position, elements, count, comm)
+    @ccall libt8.t8_element_MPI_Unpack(ts::Ptr{t8_eclass_scheme_c}, recvbuf::Ptr{Cvoid}, buffer_size::Cint, position::Ptr{Cint}, elements::Ptr{Ptr{t8_element_t}}, count::Cuint, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_element_shape_num_faces(element_shape)
+
+The number of codimension-one boundaries of an element class.
+
+### Prototype
+```c
+int t8_element_shape_num_faces (int element_shape);
+```
+"""
+function t8_element_shape_num_faces(element_shape)
+    @ccall libt8.t8_element_shape_num_faces(element_shape::Cint)::Cint
+end
+
+"""
+    t8_element_shape_max_num_faces(element_shape)
+
+For each dimension the maximum possible number of faces of an element\\_shape of that dimension.
+
+### Prototype
+```c
+int t8_element_shape_max_num_faces (int element_shape);
+```
+"""
+function t8_element_shape_max_num_faces(element_shape)
+    @ccall libt8.t8_element_shape_max_num_faces(element_shape::Cint)::Cint
+end
+
+"""
+    t8_element_shape_num_vertices(element_shape)
+
+The number of vertices of an element class.
+
+### Prototype
+```c
+int t8_element_shape_num_vertices (int element_shape);
+```
+"""
+function t8_element_shape_num_vertices(element_shape)
+    @ccall libt8.t8_element_shape_num_vertices(element_shape::Cint)::Cint
+end
+
+"""
+    t8_element_shape_vtk_type(element_shape)
+
+The vtk cell type for the element\\_shape
+
+### Prototype
+```c
+int t8_element_shape_vtk_type (int element_shape);
+```
+"""
+function t8_element_shape_vtk_type(element_shape)
+    @ccall libt8.t8_element_shape_vtk_type(element_shape::Cint)::Cint
+end
+
+"""
+    t8_element_shape_vtk_corner_number(element_shape, index)
+
+Maps the t8code corner number of the element to the vtk corner number
+
+### Prototype
+```c
+int t8_element_shape_vtk_corner_number (int element_shape, int index);
+```
+"""
+function t8_element_shape_vtk_corner_number(element_shape, index)
+    @ccall libt8.t8_element_shape_vtk_corner_number(element_shape::Cint, index::Cint)::Cint
+end
+
+"""
+    t8_element_shape_to_string(element_shape)
+
+For each element\\_shape, the name of this class as a string
+
+### Prototype
+```c
+const char* t8_element_shape_to_string (int element_shape);
+```
+"""
+function t8_element_shape_to_string(element_shape)
+    @ccall libt8.t8_element_shape_to_string(element_shape::Cint)::Cstring
+end
+
+"""
+    t8_element_shape_compare(element_shape1, element_shape2)
+
+Compare two element\\_shapees of the same dimension as necessary for face neighbor orientation. The implemented order is Triangle < Square in 2D and Tet < Hex < Prism < Pyramid in 3D.
+
+# Arguments
+* `element_shape1`:\\[in\\] The first element\\_shape to compare.
+* `element_shape2`:\\[in\\] The second element\\_shape to compare.
+# Returns
+0 if the element\\_shapees are equal, 1 if element\\_shape1 > element\\_shape2 and -1 if element\\_shape1 < element\\_shape2
+### Prototype
+```c
+int t8_element_shape_compare (t8_element_shape_t element_shape1, t8_element_shape_t element_shape2);
+```
+"""
+function t8_element_shape_compare(element_shape1, element_shape2)
+    @ccall libt8.t8_element_shape_compare(element_shape1::t8_element_shape_t, element_shape2::t8_element_shape_t)::Cint
+end
+
+"""
+    t8_forest
+
+| Field                   | Note                                                                                                                                                                                                                                                                                           |
+| :---------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rc                      | Reference counter.                                                                                                                                                                                                                                                                             |
+| set\\_level             | Level to use in new construction.                                                                                                                                                                                                                                                              |
+| set\\_for\\_coarsening  | Change partition to allow for one round of coarsening                                                                                                                                                                                                                                          |
+| cmesh                   | Coarse mesh to use.                                                                                                                                                                                                                                                                            |
+| scheme\\_cxx            | Scheme for element types.                                                                                                                                                                                                                                                                      |
+| maxlevel                | The maximum allowed refinement level for elements in this forest.                                                                                                                                                                                                                              |
+| maxlevel\\_existing     | If >= 0, the maximum occurring refinemnent level of a forest element.                                                                                                                                                                                                                          |
+| do\\_dup                | Communicator shall be duped.                                                                                                                                                                                                                                                                   |
+| dimension               | Dimension inferred from **cmesh**.                                                                                                                                                                                                                                                             |
+| incomplete\\_trees      | Flag to check whether the forest has (potential) incomplete trees. A tree is incomplete if an element has been removed from it. Once an element got removed, the flag sets to 1 (true) and stays.  For a committed forest this flag is either true on all ranks or false on all ranks.         |
+| set\\_from              | Temporarily store source forest.                                                                                                                                                                                                                                                               |
+| from\\_method           | Method to derive from **set_from**.                                                                                                                                                                                                                                                            |
+| set\\_adapt\\_fn        | refinement and coarsen function. Called when **from_method** is set to [`T8_FOREST_FROM_ADAPT`](@ref).                                                                                                                                                                                         |
+| set\\_adapt\\_recursive | Flag to decide whether coarsen and refine are carried out recursive                                                                                                                                                                                                                            |
+| set\\_balance           | Flag to decide whether to forest will be balance in t8_forest_commit. See t8_forest_set_balance. If 0, no balance. If 1 balance with repartitioning, if 2 balance without repartitioning,  # See also [`t8_forest_balance`](@ref)                                                              |
+| do\\_ghost              | If True, a ghost layer will be created when the forest is committed.                                                                                                                                                                                                                           |
+| ghost\\_type            | If a ghost layer will be created, the type of neighbors that count as ghost.                                                                                                                                                                                                                   |
+| ghost\\_algorithm       | Controls the algorithm used for ghost. 1 = balanced only. 2 = also unbalanced 3 = top-down search and unbalanced.                                                                                                                                                                              |
+| user\\_data             | Pointer for arbitrary user data.  # See also [`t8_forest_set_user_data`](@ref).                                                                                                                                                                                                                |
+| user\\_function         | Pointer for arbitrary user function.  # See also [`t8_forest_set_user_function`](@ref).                                                                                                                                                                                                        |
+| t8code\\_data           | Pointer for arbitrary data that is used internally.                                                                                                                                                                                                                                            |
+| committed               | t8_forest_commit called?                                                                                                                                                                                                                                                                       |
+| mpisize                 | Number of MPI processes.                                                                                                                                                                                                                                                                       |
+| mpirank                 | Number of this MPI process.                                                                                                                                                                                                                                                                    |
+| first\\_local\\_tree    | The global index of the first local tree on this process.  If first\\_local\\_tree is larger than last\\_local\\_tree then  this processor/forest is empty. See https://github.com/DLR-AMR/t8code/wiki/Tree-indexing                                                                           |
+| last\\_local\\_tree     | The global index of the last local tree on this process. -1 if this processor is empty.                                                                                                                                                                                                        |
+| global\\_num\\_trees    | The total number of global trees                                                                                                                                                                                                                                                               |
+| ghosts                  | If not NULL, the ghost elements.  # See also [`t8_forest_ghost`](@ref).h                                                                                                                                                                                                                       |
+| element\\_offsets       | If partitioned, for each process the global index of its first element. Since it is memory consuming, it is usually only constructed when needed and otherwise unallocated.                                                                                                                    |
+| global\\_first\\_desc   | If partitioned, for each process the linear id (at maxlevel) of its first element's first descendant. t8_element_set_linear_id. Stores 0 for empty processes. Since it is memory consuming, it is usually only constructed when needed and otherwise unallocated.                              |
+| tree\\_offsets          | If partitioned for each process the global index of its first local tree or -(first local tree) - 1 if the first tree on that process is shared. Since this is memory consuming we only construct it when needed. This array follows the same logic as *tree_offsets* in [`t8_cmesh_t`](@ref)  |
+| local\\_num\\_elements  | Number of elements on this processor.                                                                                                                                                                                                                                                          |
+| global\\_num\\_elements | Number of elements on all processors.                                                                                                                                                                                                                                                          |
+| profile                 | If not NULL, runtimes and statistics about forest\\_commit are stored here.                                                                                                                                                                                                                    |
+"""
+# struct t8_forest
+#     rc::t8_refcount_t
+#     set_level::Cint
+#     set_for_coarsening::Cint
+#     mpicomm::MPI_Comm
+#     cmesh::t8_cmesh_t
+#     scheme_cxx::Ptr{t8_scheme_cxx_t}
+#     maxlevel::Cint
+#     maxlevel_existing::Cint
+#     do_dup::Cint
+#     dimension::Cint
+#     incomplete_trees::Cint
+#     set_from::t8_forest_t
+#     from_method::t8_forest_from_t
+#     set_adapt_fn::t8_forest_adapt_t
+#     set_adapt_recursive::Cint
+#     set_balance::Cint
+#     do_ghost::Cint
+#     ghost_type::t8_ghost_type_t
+#     ghost_algorithm::Cint
+#     user_data::Ptr{Cvoid}
+#     user_function::Ptr{Cvoid}
+#     t8code_data::Ptr{Cvoid}
+#     committed::Cint
+#     mpisize::Cint
+#     mpirank::Cint
+#     first_local_tree::t8_gloidx_t
+#     last_local_tree::t8_gloidx_t
+#     global_num_trees::t8_gloidx_t
+#     trees::Ptr{sc_array_t}
+#     ghosts::t8_forest_ghost_t
+#     element_offsets::t8_shmem_array_t
+#     global_first_desc::t8_shmem_array_t
+#     tree_offsets::t8_shmem_array_t
+#     local_num_elements::t8_locidx_t
+#     global_num_elements::t8_gloidx_t
+#     profile::Ptr{t8_profile_t}
+#     stats::NTuple{14, sc_statinfo_t}
+#     stats_computed::Cint
+# end
+
+# This struct is not supposed to be read and modified directly.
+# Besides, there is a circular dependency with `t8_forest_t`
+# leading to an error output by Julia.
+mutable struct t8_forest end
+
+"""Opaque pointer to a forest implementation."""
+const t8_forest_t = Ptr{t8_forest}
+
+"""
+    t8_forest_write_netcdf(forest, file_prefix, file_title, dim, num_extern_netcdf_vars, ext_variables, comm)
+
+### Prototype
+```c
+void t8_forest_write_netcdf (t8_forest_t forest, const char *file_prefix, const char *file_title, int dim, int num_extern_netcdf_vars, t8_netcdf_variable_t *ext_variables[], sc_MPI_Comm comm);
+```
+"""
+function t8_forest_write_netcdf(forest, file_prefix, file_title, dim, num_extern_netcdf_vars, ext_variables, comm)
+    @ccall libt8.t8_forest_write_netcdf(forest::t8_forest_t, file_prefix::Cstring, file_title::Cstring, dim::Cint, num_extern_netcdf_vars::Cint, ext_variables::Ptr{Ptr{t8_netcdf_variable_t}}, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_forest_write_netcdf_ext(forest, file_prefix, file_title, dim, num_extern_netcdf_vars, ext_variables, comm, netcdf_var_storage_mode, netcdf_var_mpi_access)
+
+### Prototype
+```c
+void t8_forest_write_netcdf_ext (t8_forest_t forest, const char *file_prefix, const char *file_title, int dim, int num_extern_netcdf_vars, t8_netcdf_variable_t *ext_variables[], sc_MPI_Comm comm, int netcdf_var_storage_mode, int netcdf_var_mpi_access);
+```
+"""
+function t8_forest_write_netcdf_ext(forest, file_prefix, file_title, dim, num_extern_netcdf_vars, ext_variables, comm, netcdf_var_storage_mode, netcdf_var_mpi_access)
+    @ccall libt8.t8_forest_write_netcdf_ext(forest::t8_forest_t, file_prefix::Cstring, file_title::Cstring, dim::Cint, num_extern_netcdf_vars::Cint, ext_variables::Ptr{Ptr{t8_netcdf_variable_t}}, comm::MPI_Comm, netcdf_var_storage_mode::Cint, netcdf_var_mpi_access::Cint)::Cvoid
+end
+
+"""
+    t8_mat_init_xrot(mat, angle)
+
+Initialize given 3x3 matrix as rotation matrix around the x-axis with given angle.
+
+# Arguments
+* `mat`:\\[in,out\\] 3x3-matrix.
+* `angle`:\\[in\\] Rotation angle in radians.
+### Prototype
+```c
+static inline void t8_mat_init_xrot (double mat[3][3], const double angle);
+```
+"""
+function t8_mat_init_xrot(mat, angle)
+    @ccall libt8.t8_mat_init_xrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
+end
+
+"""
+    t8_mat_init_yrot(mat, angle)
+
+Initialize given 3x3 matrix as rotation matrix around the y-axis with given angle.
+
+# Arguments
+* `mat`:\\[in,out\\] 3x3-matrix.
+* `angle`:\\[in\\] Rotation angle in radians.
+### Prototype
+```c
+static inline void t8_mat_init_yrot (double mat[3][3], const double angle);
+```
+"""
+function t8_mat_init_yrot(mat, angle)
+    @ccall libt8.t8_mat_init_yrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
+end
+
+"""
+    t8_mat_init_zrot(mat, angle)
+
+Initialize given 3x3 matrix as rotation matrix around the z-axis with given angle.
+
+# Arguments
+* `mat`:\\[in,out\\] 3x3-matrix.
+* `angle`:\\[in\\] Rotation angle in radians.
+### Prototype
+```c
+static inline void t8_mat_init_zrot (double mat[3][3], const double angle);
+```
+"""
+function t8_mat_init_zrot(mat, angle)
+    @ccall libt8.t8_mat_init_zrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
+end
+
+"""
+    t8_mat_mult_vec(mat, a, b)
+
+Apply matrix-matrix multiplication: b = M*a.
+
+# Arguments
+* `mat`:\\[in\\] 3x3-matrix.
+* `a`:\\[in\\] 3-vector.
+* `b`:\\[in,out\\] 3-vector.
+### Prototype
+```c
+static inline void t8_mat_mult_vec (const double mat[3][3], const double a[3], double b[3]);
+```
+"""
+function t8_mat_mult_vec(mat, a, b)
+    @ccall libt8.t8_mat_mult_vec(mat::Ptr{NTuple{3, Cdouble}}, a::Ptr{Cdouble}, b::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_mat_mult_mat(A, B, C)
+
+Apply matrix-matrix multiplication: C = A*B.
+
+# Arguments
+* `A`:\\[in\\] 3x3-matrix.
+* `B`:\\[in\\] 3x3-matrix.
+* `C`:\\[in\\] 3x3-matrix.
+### Prototype
+```c
+static inline void t8_mat_mult_mat (const double A[3][3], const double B[3][3], double C[3][3]);
+```
+"""
+function t8_mat_mult_mat(A, B, C)
+    @ccall libt8.t8_mat_mult_mat(A::Ptr{NTuple{3, Cdouble}}, B::Ptr{NTuple{3, Cdouble}}, C::Ptr{NTuple{3, Cdouble}})::Cvoid
+end
+
+mutable struct t8_mesh end
+
+const t8_mesh_t = t8_mesh
+
+"""
+    t8_mesh_new(dimension, Kglobal, Klocal)
+
+*********************** preallocate *************************
+
+### Prototype
+```c
+t8_mesh_t * t8_mesh_new (int dimension, t8_gloidx_t Kglobal, t8_locidx_t Klocal);
+```
+"""
+function t8_mesh_new(dimension, Kglobal, Klocal)
+    @ccall libt8.t8_mesh_new(dimension::Cint, Kglobal::t8_gloidx_t, Klocal::t8_locidx_t)::Ptr{t8_mesh_t}
+end
+
+"""
+    t8_mesh_new_unitcube(theclass)
+
+*********** all-in-one convenience constructors *************
+
+### Prototype
+```c
+t8_mesh_t * t8_mesh_new_unitcube (t8_eclass_t theclass);
+```
+"""
+function t8_mesh_new_unitcube(theclass)
+    @ccall libt8.t8_mesh_new_unitcube(theclass::t8_eclass_t)::Ptr{t8_mesh_t}
+end
+
+"""
+    t8_mesh_set_comm(mesh, comm)
+
+### Prototype
+```c
+void t8_mesh_set_comm (t8_mesh_t *mesh, sc_MPI_Comm comm);
+```
+"""
+function t8_mesh_set_comm(mesh, comm)
+    @ccall libt8.t8_mesh_set_comm(mesh::Ptr{t8_mesh_t}, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_mesh_set_partition(mesh, enable)
+
+Determine whether we partition in t8_mesh_build. Default true.
+
+### Prototype
+```c
+void t8_mesh_set_partition (t8_mesh_t *mesh, int enable);
+```
+"""
+function t8_mesh_set_partition(mesh, enable)
+    @ccall libt8.t8_mesh_set_partition(mesh::Ptr{t8_mesh_t}, enable::Cint)::Cvoid
+end
+
+"""
+    t8_mesh_set_element(mesh, theclass, gloid, locid)
+
+### Prototype
+```c
+void t8_mesh_set_element (t8_mesh_t *mesh, t8_eclass_t theclass, t8_gloidx_t gloid, t8_locidx_t locid);
+```
+"""
+function t8_mesh_set_element(mesh, theclass, gloid, locid)
+    @ccall libt8.t8_mesh_set_element(mesh::Ptr{t8_mesh_t}, theclass::t8_eclass_t, gloid::t8_gloidx_t, locid::t8_locidx_t)::Cvoid
+end
+
+"""
+    t8_mesh_set_local_to_global(mesh, ltog_length, ltog)
+
+### Prototype
+```c
+void t8_mesh_set_local_to_global (t8_mesh_t *mesh, t8_locidx_t ltog_length, const t8_gloidx_t *ltog);
+```
+"""
+function t8_mesh_set_local_to_global(mesh, ltog_length, ltog)
+    @ccall libt8.t8_mesh_set_local_to_global(mesh::Ptr{t8_mesh_t}, ltog_length::t8_locidx_t, ltog::Ptr{t8_gloidx_t})::Cvoid
+end
+
+"""
+    t8_mesh_set_face(mesh, locid1, face1, locid2, face2, orientation)
+
+### Prototype
+```c
+void t8_mesh_set_face (t8_mesh_t *mesh, t8_locidx_t locid1, int face1, t8_locidx_t locid2, int face2, int orientation);
+```
+"""
+function t8_mesh_set_face(mesh, locid1, face1, locid2, face2, orientation)
+    @ccall libt8.t8_mesh_set_face(mesh::Ptr{t8_mesh_t}, locid1::t8_locidx_t, face1::Cint, locid2::t8_locidx_t, face2::Cint, orientation::Cint)::Cvoid
+end
+
+"""
+    t8_mesh_set_element_vertices(mesh, locid, vids_length, vids)
+
+### Prototype
+```c
+void t8_mesh_set_element_vertices (t8_mesh_t *mesh, t8_locidx_t locid, t8_locidx_t vids_length, const t8_locidx_t *vids);
+```
+"""
+function t8_mesh_set_element_vertices(mesh, locid, vids_length, vids)
+    @ccall libt8.t8_mesh_set_element_vertices(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t, vids_length::t8_locidx_t, vids::Ptr{t8_locidx_t})::Cvoid
+end
+
+"""
+    t8_mesh_build(mesh)
+
+Setup a mesh and turn it into a usable object.
+
+### Prototype
+```c
+void t8_mesh_build (t8_mesh_t *mesh);
+```
+"""
+function t8_mesh_build(mesh)
+    @ccall libt8.t8_mesh_build(mesh::Ptr{t8_mesh_t})::Cvoid
+end
+
+"""
+    t8_mesh_get_comm(mesh)
+
+### Prototype
+```c
+sc_MPI_Comm t8_mesh_get_comm (t8_mesh_t *mesh);
+```
+"""
+function t8_mesh_get_comm(mesh)
+    @ccall libt8.t8_mesh_get_comm(mesh::Ptr{t8_mesh_t})::Cint
+end
+
+"""
+    t8_mesh_get_element_count(mesh, theclass)
+
+### Prototype
+```c
+t8_locidx_t t8_mesh_get_element_count (t8_mesh_t *mesh, t8_eclass_t theclass);
+```
+"""
+function t8_mesh_get_element_count(mesh, theclass)
+    @ccall libt8.t8_mesh_get_element_count(mesh::Ptr{t8_mesh_t}, theclass::t8_eclass_t)::t8_locidx_t
+end
+
+"""
+    t8_mesh_get_element_class(mesh, locid)
+
+# Arguments
+* `locid`:\\[in\\] The local number can specify a point of any dimension that is locally relevant. The points are ordered in reverse to the element classes in t8_eclass_t. The local index is cumulative in this order.
+### Prototype
+```c
+t8_locidx_t t8_mesh_get_element_class (t8_mesh_t *mesh, t8_locidx_t locid);
+```
+"""
+function t8_mesh_get_element_class(mesh, locid)
+    @ccall libt8.t8_mesh_get_element_class(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t)::t8_locidx_t
+end
+
+"""
+    t8_mesh_get_element_locid(mesh, gloid)
+
+### Prototype
+```c
+t8_locidx_t t8_mesh_get_element_locid (t8_mesh_t *mesh, t8_gloidx_t gloid);
+```
+"""
+function t8_mesh_get_element_locid(mesh, gloid)
+    @ccall libt8.t8_mesh_get_element_locid(mesh::Ptr{t8_mesh_t}, gloid::t8_gloidx_t)::t8_locidx_t
+end
+
+"""
+    t8_mesh_get_element_gloid(mesh, locid)
+
+### Prototype
+```c
+t8_gloidx_t t8_mesh_get_element_gloid (t8_mesh_t *mesh, t8_locidx_t locid);
+```
+"""
+function t8_mesh_get_element_gloid(mesh, locid)
+    @ccall libt8.t8_mesh_get_element_gloid(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t)::t8_gloidx_t
+end
+
+"""
+    t8_mesh_get_element(mesh, locid)
+
+### Prototype
+```c
+t8_element_t t8_mesh_get_element (t8_mesh_t *mesh, t8_locidx_t locid);
+```
+"""
+function t8_mesh_get_element(mesh, locid)
+    @ccall libt8.t8_mesh_get_element(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t)::t8_element_t
+end
+
+"""
+    t8_mesh_get_element_boundary(mesh, locid, length_boundary, elemid, orientation)
+
+### Prototype
+```c
+void t8_mesh_get_element_boundary (t8_mesh_t *mesh, t8_locidx_t locid, int length_boundary, t8_locidx_t *elemid, int *orientation);
+```
+"""
+function t8_mesh_get_element_boundary(mesh, locid, length_boundary, elemid, orientation)
+    @ccall libt8.t8_mesh_get_element_boundary(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t, length_boundary::Cint, elemid::Ptr{t8_locidx_t}, orientation::Ptr{Cint})::Cvoid
+end
+
+"""
+    t8_mesh_get_maximum_support(mesh)
+
+Return the maximum of the length of the support of any local element.
+
+### Prototype
+```c
+int t8_mesh_get_maximum_support (t8_mesh_t *mesh);
+```
+"""
+function t8_mesh_get_maximum_support(mesh)
+    @ccall libt8.t8_mesh_get_maximum_support(mesh::Ptr{t8_mesh_t})::Cint
+end
+
+"""
+    t8_mesh_get_element_support(mesh, locid, length_support, elemid, orientation)
+
+# Arguments
+* `length_support`:\\[in,out\\]
+### Prototype
+```c
+void t8_mesh_get_element_support (t8_mesh_t *mesh, t8_locidx_t locid, int *length_support, t8_locidx_t *elemid, int *orientation);
+```
+"""
+function t8_mesh_get_element_support(mesh, locid, length_support, elemid, orientation)
+    @ccall libt8.t8_mesh_get_element_support(mesh::Ptr{t8_mesh_t}, locid::t8_locidx_t, length_support::Ptr{Cint}, elemid::Ptr{t8_locidx_t}, orientation::Ptr{Cint})::Cvoid
+end
+
+"""
+    t8_mesh_destroy(mesh)
+
+*************************** destruct ************************
+
+### Prototype
+```c
+void t8_mesh_destroy (t8_mesh_t *mesh);
+```
+"""
+function t8_mesh_destroy(mesh)
+    @ccall libt8.t8_mesh_destroy(mesh::Ptr{t8_mesh_t})::Cvoid
+end
+
+const t8_nc_int64_t = Int64
+
+const t8_nc_int32_t = Int32
+
+"""
+    t8_netcdf_create_var(var_type, var_name, var_long_name, var_unit, var_data)
+
+Create an extern double variable which additionally should be put out to the NetCDF File
+
+# Arguments
+* `var_type`:\\[in\\] Defines the datatype of the variable, either T8\\_NETCDF\\_INT, T8\\_NETCDF\\_INT64 or T8\\_NETCDF\\_DOUBLE.
+* `var_name`:\\[in\\] A String which will be the name of the created variable.
+* `var_long_name`:\\[in\\] A string describing the variable a bit more and what it is about.
+* `var_unit`:\\[in\\] The units in which the data is provided.
+* `var_data`:\\[in\\] A [`sc_array_t`](@ref) holding the elementwise data of the variable.
+* `num_extern_netcdf_vars`:\\[in\\] The number of extern user-defined variables which hold elementwise data (if none, set it to 0).
+### Prototype
+```c
+t8_netcdf_variable_t * t8_netcdf_create_var (t8_netcdf_variable_type_t var_type, const char *var_name, const char *var_long_name, const char *var_unit, sc_array_t *var_data);
+```
+"""
+function t8_netcdf_create_var(var_type, var_name, var_long_name, var_unit, var_data)
+    @ccall libt8.t8_netcdf_create_var(var_type::t8_netcdf_variable_type_t, var_name::Cstring, var_long_name::Cstring, var_unit::Cstring, var_data::Ptr{sc_array_t})::Ptr{t8_netcdf_variable_t}
+end
+
+"""
+    t8_netcdf_create_integer_var(var_name, var_long_name, var_unit, var_data)
+
+Create an extern integer variable which additionally should be put out to the NetCDF File (The distinction if it will be a NC\\_INT or NC\\_INT64 variable is based on the elementsize of the given [`sc_array_t`](@ref))
+
+# Arguments
+* `var_name`:\\[in\\] A String which will be the name of the created variable.
+* `var_long_name`:\\[in\\] A string describing the variable a bit more and what it is about.
+* `var_unit`:\\[in\\] The units in which the data is provided.
+* `var_data`:\\[in\\] A [`sc_array_t`](@ref) holding the elementwise data of the variable.
+* `num_extern_netcdf_vars`:\\[in\\] The number of extern user-defined variables which hold elementwise data (if none, set it to 0).
+### Prototype
+```c
+t8_netcdf_variable_t * t8_netcdf_create_integer_var (const char *var_name, const char *var_long_name, const char *var_unit, sc_array_t *var_data);
+```
+"""
+function t8_netcdf_create_integer_var(var_name, var_long_name, var_unit, var_data)
+    @ccall libt8.t8_netcdf_create_integer_var(var_name::Cstring, var_long_name::Cstring, var_unit::Cstring, var_data::Ptr{sc_array_t})::Ptr{t8_netcdf_variable_t}
+end
+
+"""
+    t8_netcdf_create_double_var(var_name, var_long_name, var_unit, var_data)
+
+Create an extern double variable which additionally should be put out to the NetCDF File
+
+# Arguments
+* `var_name`:\\[in\\] A String which will be the name of the created variable.
+* `var_long_name`:\\[in\\] A string describing the variable a bit more and what it is about.
+* `var_unit`:\\[in\\] The units in which the data is provided.
+* `var_data`:\\[in\\] A [`sc_array_t`](@ref) holding the elementwise data of the variable.
+* `num_extern_netcdf_vars`:\\[in\\] The number of extern user-defined variables which hold elementwise data (if none, set it to 0).
+### Prototype
+```c
+t8_netcdf_variable_t * t8_netcdf_create_double_var (const char *var_name, const char *var_long_name, const char *var_unit, sc_array_t *var_data);
+```
+"""
+function t8_netcdf_create_double_var(var_name, var_long_name, var_unit, var_data)
+    @ccall libt8.t8_netcdf_create_double_var(var_name::Cstring, var_long_name::Cstring, var_unit::Cstring, var_data::Ptr{sc_array_t})::Ptr{t8_netcdf_variable_t}
+end
+
+"""
+    t8_netcdf_variable_destroy(var_destroy)
+
+Free the allocated memory of the a [`t8_netcdf_variable_t`](@ref)
+
+# Arguments
+* `var_destroy`:\\[in\\] A t8\\_netcdf\\_t variable whose allocated memory should be freed.
+### Prototype
+```c
+void t8_netcdf_variable_destroy (t8_netcdf_variable_t *var_destroy);
+```
+"""
+function t8_netcdf_variable_destroy(var_destroy)
+    @ccall libt8.t8_netcdf_variable_destroy(var_destroy::Ptr{t8_netcdf_variable_t})::Cvoid
+end
+
+"""
+    t8_refcount_init(rc)
+
+Initialize a reference counter to 1. It is legal if its status prior to this call is undefined.
+
+# Arguments
+* `rc`:\\[out\\] The reference counter is set to one by this call.
+### Prototype
+```c
+void t8_refcount_init (t8_refcount_t *rc);
+```
+"""
+function t8_refcount_init(rc)
+    @ccall libt8.t8_refcount_init(rc::Ptr{t8_refcount_t})::Cvoid
+end
+
+"""
+    t8_refcount_new()
+
+Create a new reference counter with count initialized to 1. Equivalent to calling [`t8_refcount_init`](@ref) on a newly allocated refcount\\_t. It is mandatory to free this with t8_refcount_destroy.
+
+# Returns
+An allocated reference counter whose count has been set to one.
+### Prototype
+```c
+t8_refcount_t * t8_refcount_new (void);
+```
+"""
+function t8_refcount_new()
+    @ccall libt8.t8_refcount_new()::Ptr{t8_refcount_t}
+end
+
+"""
+    t8_refcount_destroy(rc)
+
+Destroy a reference counter that we allocated with t8_refcount_new. Its reference count must have decreased to zero.
+
+# Arguments
+* `rc`:\\[in,out\\] Allocated, formerly valid reference counter.
+### Prototype
+```c
+void t8_refcount_destroy (t8_refcount_t *rc);
+```
+"""
+function t8_refcount_destroy(rc)
+    @ccall libt8.t8_refcount_destroy(rc::Ptr{t8_refcount_t})::Cvoid
+end
+
+"""
+    t8_vec_norm(vec)
+
+Vector norm.
+
+# Arguments
+* `vec`:\\[in\\] A 3D vector.
+# Returns
+The norm of *vec*.
+### Prototype
+```c
+static inline double t8_vec_norm (const double vec[3]);
+```
+"""
+function t8_vec_norm(vec)
+    @ccall libt8.t8_vec_norm(vec::Ptr{Cdouble})::Cdouble
+end
+
+"""
+    t8_vec_normalize(vec)
+
+Normalize a vector.
+
+# Arguments
+* `vec`:\\[in,out\\] A 3D vector.
+### Prototype
+```c
+static inline void t8_vec_normalize (double vec[3]);
+```
+"""
+function t8_vec_normalize(vec)
+    @ccall libt8.t8_vec_normalize(vec::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_copy(vec_in, vec_out)
+
+Make a copy of a vector.
+
+# Arguments
+* `vec_in`:\\[in\\]
+* `vec_out`:\\[out\\]
+### Prototype
+```c
+static inline void t8_vec_copy (const double vec_in[3], double vec_out[3]);
+```
+"""
+function t8_vec_copy(vec_in, vec_out)
+    @ccall libt8.t8_vec_copy(vec_in::Ptr{Cdouble}, vec_out::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_dist(vec_x, vec_y)
+
+Euclidean distance of X and Y.
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in\\] A 3D vector.
+# Returns
+The euclidean distance. Equivalent to norm (X-Y).
+### Prototype
+```c
+static inline double t8_vec_dist (const double vec_x[3], const double vec_y[3]);
+```
+"""
+function t8_vec_dist(vec_x, vec_y)
+    @ccall libt8.t8_vec_dist(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble})::Cdouble
+end
+
+"""
+    t8_vec_ax(vec_x, alpha)
+
+Compute X = alpha * X
+
+# Arguments
+* `vec_x`:\\[in,out\\] A 3D vector. On output set to *alpha* * *vec_x*.
+* `alpha`:\\[in\\] A factor.
+### Prototype
+```c
+static inline void t8_vec_ax (double vec_x[3], const double alpha);
+```
+"""
+function t8_vec_ax(vec_x, alpha)
+    @ccall libt8.t8_vec_ax(vec_x::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_axy(vec_x, vec_y, alpha)
+
+Compute Y = alpha * X
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_z`:\\[out\\] On output set to *alpha* * *vec_x*.
+* `alpha`:\\[in\\] A factor.
+### Prototype
+```c
+static inline void t8_vec_axy (const double vec_x[3], double vec_y[3], const double alpha);
+```
+"""
+function t8_vec_axy(vec_x, vec_y, alpha)
+    @ccall libt8.t8_vec_axy(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_axb(vec_x, vec_y, alpha, b)
+
+Y = alpha * X + b
+
+!!! note
+
+    It is possible that vec\\_x = vec\\_y on input to overwrite x
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[out\\] On input, a 3D vector. On output set to *alpha* * *vec_x* + *b*.
+* `alpha`:\\[in\\] A factor.
+* `b`:\\[in\\] An offset.
+### Prototype
+```c
+static inline void t8_vec_axb (const double vec_x[3], double vec_y[3], const double alpha, const double b);
+```
+"""
+function t8_vec_axb(vec_x, vec_y, alpha, b)
+    @ccall libt8.t8_vec_axb(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble, b::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_axpy(vec_x, vec_y, alpha)
+
+Y = Y + alpha * X
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in,out\\] On input, a 3D vector. On output set *to* vec\\_y + *alpha* * *vec_x*
+* `alpha`:\\[in\\] A factor.
+### Prototype
+```c
+static inline void t8_vec_axpy (const double vec_x[3], double vec_y[3], const double alpha);
+```
+"""
+function t8_vec_axpy(vec_x, vec_y, alpha)
+    @ccall libt8.t8_vec_axpy(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_axpyz(vec_x, vec_y, vec_z, alpha)
+
+Z = Y + alpha * X
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in\\] A 3D vector.
+* `vec_z`:\\[out\\] On output set *to* vec\\_y + *alpha* * *vec_x*
+### Prototype
+```c
+static inline void t8_vec_axpyz (const double vec_x[3], const double vec_y[3], double vec_z[3], const double alpha);
+```
+"""
+function t8_vec_axpyz(vec_x, vec_y, vec_z, alpha)
+    @ccall libt8.t8_vec_axpyz(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, vec_z::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_dot(vec_x, vec_y)
+
+Dot product of X and Y.
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in\\] A 3D vector.
+# Returns
+The dot product *vec_x* * *vec_y*
+### Prototype
+```c
+static inline double t8_vec_dot (const double vec_x[3], const double vec_y[3]);
+```
+"""
+function t8_vec_dot(vec_x, vec_y)
+    @ccall libt8.t8_vec_dot(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble})::Cdouble
+end
+
+"""
+    t8_vec_cross(vec_x, vec_y, cross)
+
+Cross product of X and Y
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in\\] A 3D vector.
+* `cross`:\\[out\\] On output, the cross product of *vec_x* and *vec_y*.
+### Prototype
+```c
+static inline void t8_vec_cross (const double vec_x[3], const double vec_y[3], double cross[3]);
+```
+"""
+function t8_vec_cross(vec_x, vec_y, cross)
+    @ccall libt8.t8_vec_cross(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, cross::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_diff(vec_x, vec_y, diff)
+
+Compute the difference of two vectors.
+
+# Arguments
+* `vec_x`:\\[in\\] A 3D vector.
+* `vec_y`:\\[in\\] A 3D vector.
+* `diff`:\\[out\\] On output, the difference of *vec_x* and *vec_y*.
+### Prototype
+```c
+static inline void t8_vec_diff (const double vec_x[3], const double vec_y[3], double diff[3]);
+```
+"""
+function t8_vec_diff(vec_x, vec_y, diff)
+    @ccall libt8.t8_vec_diff(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, diff::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_eq(vec_x, vec_y, tol)
+
+Check the equality of two vectors elementwise
+
+# Arguments
+* `vec_x`:\\[in\\]
+* `vec_y`:\\[in\\]
+* `tol`:\\[in\\]
+# Returns
+true, if the vectors are equal up to *tol*
+### Prototype
+```c
+static inline int t8_vec_eq (const double vec_x[3], const double vec_y[3], const double tol);
+```
+"""
+function t8_vec_eq(vec_x, vec_y, tol)
+    @ccall libt8.t8_vec_eq(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, tol::Cdouble)::Cint
+end
+
+"""
+    t8_vec_rescale(vec, new_length)
+
+Rescale a vector to a new length.
+
+# Arguments
+* `vec`:\\[in,out\\] A 3D vector.
+* `new_length`:\\[in\\] New length of the vector.
+### Prototype
+```c
+static inline void t8_vec_rescale (double vec[3], const double new_length);
+```
+"""
+function t8_vec_rescale(vec, new_length)
+    @ccall libt8.t8_vec_rescale(vec::Ptr{Cdouble}, new_length::Cdouble)::Cvoid
+end
+
+"""
+    t8_vec_tri_normal(p1, p2, p3, normal)
+
+Compute the normal of a triangle given by its three vertices.
+
+# Arguments
+* `p1`:\\[in\\] A 3D vector.
+* `p2`:\\[in\\] A 3D vector.
+* `p3`:\\[in\\] A 3D vector.
+* `Normal`:\\[out\\] vector of the triangle. (Not necessarily of length 1!)
+### Prototype
+```c
+static inline void t8_vec_tri_normal (const double p1[3], const double p2[3], const double p3[3], double normal[3]);
+```
+"""
+function t8_vec_tri_normal(p1, p2, p3, normal)
+    @ccall libt8.t8_vec_tri_normal(p1::Ptr{Cdouble}, p2::Ptr{Cdouble}, p3::Ptr{Cdouble}, normal::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_orthogonal_tripod(v1, v2, v3)
+
+Compute an orthogonal coordinate system from a given vector.
+
+# Arguments
+* `v1`:\\[in\\] 3D vector.
+* `v2`:\\[out\\] 3D vector.
+* `v3`:\\[out\\] 3D vector.
+### Prototype
+```c
+static inline void t8_vec_orthogonal_tripod (const double v1[3], double v2[3], double v3[3]);
+```
+"""
+function t8_vec_orthogonal_tripod(v1, v2, v3)
+    @ccall libt8.t8_vec_orthogonal_tripod(v1::Ptr{Cdouble}, v2::Ptr{Cdouble}, v3::Ptr{Cdouble})::Cvoid
+end
+
+"""
+    t8_vec_swap(p1, p2)
+
+Swap the components of two vectors.
+
+# Arguments
+* `p1`:\\[in,out\\] A 3D vector.
+* `p2`:\\[in,out\\] A 3D vector.
+### Prototype
+```c
+static inline void t8_vec_swap (double p1[3], double p2[3]);
+```
+"""
+function t8_vec_swap(p1, p2)
+    @ccall libt8.t8_vec_swap(p1::Ptr{Cdouble}, p2::Ptr{Cdouble})::Cvoid
+end
+
+# no prototype is found for this function at t8_version.h:70:1, please use with caution
+"""
+    t8_get_package_string()
+
+Return the package string of t8code. This string has the format "t8 version\\_number".
+
+# Returns
+The version string of t8code.
+### Prototype
+```c
+const char* t8_get_package_string ();
+```
+"""
+function t8_get_package_string()
+    @ccall libt8.t8_get_package_string()::Cstring
+end
+
+# no prototype is found for this function at t8_version.h:76:1, please use with caution
+"""
+    t8_get_version_number()
+
+Return the version number of t8code as a string.
+
+# Returns
+The version number of t8code as a string.
+### Prototype
+```c
+const char* t8_get_version_number ();
+```
+"""
+function t8_get_version_number()
+    @ccall libt8.t8_get_version_number()::Cstring
+end
+
+# no prototype is found for this function at t8_version.h:82:1, please use with caution
+"""
+    t8_get_version_point_string()
+
+Return the version point string.
+
+# Returns
+The version point point string.
+### Prototype
+```c
+const char* t8_get_version_point_string ();
+```
+"""
+function t8_get_version_point_string()
+    @ccall libt8.t8_get_version_point_string()::Cstring
+end
+
+# no prototype is found for this function at t8_version.h:88:1, please use with caution
+"""
+    t8_get_version_major()
+
+Return the major version number of t8code.
+
+# Returns
+The major version number of t8code.
+### Prototype
+```c
+int t8_get_version_major ();
+```
+"""
+function t8_get_version_major()
+    @ccall libt8.t8_get_version_major()::Cint
+end
+
+# no prototype is found for this function at t8_version.h:94:1, please use with caution
+"""
+    t8_get_version_minor()
+
+Return the minor version number of t8code.
+
+# Returns
+The minor version number of t8code.
+### Prototype
+```c
+int t8_get_version_minor ();
+```
+"""
+function t8_get_version_minor()
+    @ccall libt8.t8_get_version_minor()::Cint
+end
+
+# no prototype is found for this function at t8_version.h:104:1, please use with caution
+"""
+    t8_get_version_patch()
+
+Return the patch version number of t8code.
+
+!!! note
+
+
+# Returns
+The patch version number of t8code. negative on error.
+### Prototype
+```c
+int t8_get_version_patch ();
+```
+"""
+function t8_get_version_patch()
+    @ccall libt8.t8_get_version_patch()::Cint
+end
+
+@cenum t8_vtk_data_type_t::UInt32 begin
+    T8_VTK_SCALAR = 0
+    T8_VTK_VECTOR = 1
+end
+
+"""
+    t8_vtk_data_field_t
+
+| Field       | Note                                       |
+| :---------- | :----------------------------------------- |
+| type        | Describes of which type the data array is  |
+| description | String that describes the data.            |
+"""
+struct t8_vtk_data_field_t
+    type::t8_vtk_data_type_t
+    description::NTuple{8192, Cchar}
+    data::Ptr{Cdouble}
+end
+
+"""
+    t8_write_pvtu(filename, num_procs, write_tree, write_rank, write_level, write_id, num_data, data)
+
+### Prototype
+```c
+int t8_write_pvtu (const char *filename, int num_procs, int write_tree, int write_rank, int write_level, int write_id, int num_data, t8_vtk_data_field_t *data);
+```
+"""
+function t8_write_pvtu(filename, num_procs, write_tree, write_rank, write_level, write_id, num_data, data)
+    @ccall libt8.t8_write_pvtu(filename::Cstring, num_procs::Cint, write_tree::Cint, write_rank::Cint, write_level::Cint, write_id::Cint, num_data::Cint, data::Ptr{t8_vtk_data_field_t})::Cint
+end
+
+"""
+    getdelim(lineptr, n, delimiter, stream)
+
+### Prototype
+```c
+static ssize_t getdelim (char **lineptr, size_t *n, int delimiter, FILE *stream);
+```
+"""
+function getdelim(lineptr, n, delimiter, stream)
+    @ccall libt8.getdelim(lineptr::Ptr{Cstring}, n::Ptr{Cint}, delimiter::Cint, stream::Ptr{Cint})::Cint
+end
+
+"""
+    getline(lineptr, n, stream)
+
+### Prototype
+```c
+static ssize_t getline (char **lineptr, size_t *n, FILE *stream);
+```
+"""
+function getline(lineptr, n, stream)
+    @ccall libt8.getline(lineptr::Ptr{Cstring}, n::Ptr{Cint}, stream::Ptr{Cint})::Cint
+end
+
+"""
+    strsep(stringp, delim)
+
+Extract token from string up to a given delimiter.
+
+For a full description see https://linux.die.net/man/3/[`strsep`](@ref)
+
+### Prototype
+```c
+static char * strsep (char **stringp, const char *delim);
+```
+"""
+function strsep(stringp, delim)
+    @ccall libt8.strsep(stringp::Ptr{Cstring}, delim::Cstring)::Cstring
+end
+
+"""
+    t8_cmesh_copy(cmesh, cmesh_from, comm)
+
+### Prototype
+```c
+void t8_cmesh_copy (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_copy(cmesh, cmesh_from, comm)
+    @ccall libt8.t8_cmesh_copy(cmesh::t8_cmesh_t, cmesh_from::t8_cmesh_t, comm::MPI_Comm)::Cvoid
 end
 
 """
@@ -4621,7 +8327,7 @@ void sc_io_read (sc_MPI_File mpifile, void *ptr, size_t zcount, sc_MPI_Datatype 
 ```
 """
 function sc_io_read(mpifile, ptr, zcount, t, errmsg)
-    @ccall libsc.sc_io_read(mpifile::MPI_File, ptr::Ptr{Cvoid}, zcount::Csize_t, t::Cint, errmsg::Cstring)::Cvoid
+    @ccall libsc.sc_io_read(mpifile::MPI_File, ptr::Ptr{Cvoid}, zcount::Csize_t, t::MPI_Datatype, errmsg::Cstring)::Cvoid
 end
 
 """
@@ -4633,7 +8339,7 @@ void sc_io_write (sc_MPI_File mpifile, const void *ptr, size_t zcount, sc_MPI_Da
 ```
 """
 function sc_io_write(mpifile, ptr, zcount, t, errmsg)
-    @ccall libsc.sc_io_write(mpifile::MPI_File, ptr::Ptr{Cvoid}, zcount::Csize_t, t::Cint, errmsg::Cstring)::Cvoid
+    @ccall libsc.sc_io_write(mpifile::MPI_File, ptr::Ptr{Cvoid}, zcount::Csize_t, t::MPI_Datatype, errmsg::Cstring)::Cvoid
 end
 
 """Typedef for quadrant coordinates."""
@@ -5249,7 +8955,7 @@ Write memory content to a file.
 * `size`:\\[in\\] Size of one array member.
 * `nmemb`:\\[in\\] Number of array members.
 * `file`:\\[in,out\\] File pointer, must be opened for writing.
-* `errmsg`:\\[in\\] Error message passed to [`SC_CHECK_ABORT`](@ref).
+* `errmsg`:\\[in\\] Error message passed to `SC_CHECK_ABORT`.
 ### Prototype
 ```c
 void sc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE * file, const char *errmsg);
@@ -5273,7 +8979,7 @@ Read file content into memory.
 * `size`:\\[in\\] Size of one array member.
 * `nmemb`:\\[in\\] Number of array members.
 * `file`:\\[in,out\\] File pointer, must be opened for reading.
-* `errmsg`:\\[in\\] Error message passed to [`SC_CHECK_ABORT`](@ref).
+* `errmsg`:\\[in\\] Error message passed to `SC_CHECK_ABORT`.
 ### Prototype
 ```c
 void sc_fread (void *ptr, size_t size, size_t nmemb, FILE * file, const char *errmsg);
@@ -5320,7 +9026,7 @@ int sc_io_read_at (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr, int cou
 ```
 """
 function sc_io_read_at(mpifile, offset, ptr, count, t, ocount)
-    @ccall libsc.sc_io_read_at(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::Cint, ocount::Ptr{Cint})::Cint
+    @ccall libsc.sc_io_read_at(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::MPI_Datatype, ocount::Ptr{Cint})::Cint
 end
 
 """
@@ -5332,7 +9038,7 @@ int sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr, int
 ```
 """
 function sc_io_read_at_all(mpifile, offset, ptr, count, t, ocount)
-    @ccall libsc.sc_io_read_at_all(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::Cint, ocount::Ptr{Cint})::Cint
+    @ccall libsc.sc_io_read_at_all(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::MPI_Datatype, ocount::Ptr{Cint})::Cint
 end
 
 """
@@ -5344,7 +9050,7 @@ int sc_io_write_at (sc_MPI_File mpifile, sc_MPI_Offset offset, const void *ptr, 
 ```
 """
 function sc_io_write_at(mpifile, offset, ptr, count, t, ocount)
-    @ccall libsc.sc_io_write_at(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::Cint, ocount::Ptr{Cint})::Cint
+    @ccall libsc.sc_io_write_at(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::MPI_Datatype, ocount::Ptr{Cint})::Cint
 end
 
 """
@@ -5356,7 +9062,7 @@ int sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, const void *p
 ```
 """
 function sc_io_write_at_all(mpifile, offset, ptr, count, t, ocount)
-    @ccall libsc.sc_io_write_at_all(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::Cint, ocount::Ptr{Cint})::Cint
+    @ccall libsc.sc_io_write_at_all(mpifile::MPI_File, offset::Cint, ptr::Ptr{Cvoid}, count::Cint, t::MPI_Datatype, ocount::Ptr{Cint})::Cint
 end
 
 """
@@ -5435,7 +9141,7 @@ end
 """
     p4est_init(log_handler, log_threshold)
 
-Registers p4est with the SC Library and sets the logging behavior. This function is optional. This function must only be called before additional threads are created. If this function is not called or called with log\\_handler == NULL, the default SC log handler will be used. If this function is not called or called with log\\_threshold == [`SC_LP_DEFAULT`](@ref), the default SC log threshold will be used. The default SC log settings can be changed with [`sc_set_log_defaults`](@ref) ().
+Registers p4est with the SC Library and sets the logging behavior. This function is optional. This function must only be called before additional threads are created. If this function is not called or called with log\\_handler == NULL, the default SC log handler will be used. If this function is not called or called with log\\_threshold == `SC_LP_DEFAULT`, the default SC log threshold will be used. The default SC log settings can be changed with [`sc_set_log_defaults`](@ref) ().
 
 ### Prototype
 ```c
@@ -5904,30 +9610,6 @@ void p4est_connectivity_get_neighbor_transforms (p4est_connectivity_t *conn, p4e
 """
 function p4est_connectivity_get_neighbor_transforms(conn, tree_id, boundary_type, boundary_index, neighbor_transform_array)
     @ccall libp4est.p4est_connectivity_get_neighbor_transforms(conn::Ptr{p4est_connectivity_t}, tree_id::p4est_topidx_t, boundary_type::p4est_connect_type_t, boundary_index::Cint, neighbor_transform_array::Ptr{sc_array_t})::Cvoid
-end
-
-"""
-    p4est_connectivity_coordinates_canonicalize(conn, treeid, coords, treeid_out, coords_out)
-
-Determine the owning tree for a coordinate and transform it there.
-
-On a boundary between trees, different coordinate systems meet. A coordinate on a tree boundary face or corner generated from the perspective of a specific tree may be transformed into any other touching tree's coordinate system and still refer to the same point in the mesh.
-
-To uniquely identify a coordinate, this function identifies the lowest numbered tree touching this coordinate and transforms the coordinates into that system. The result can be used e. g. in topology hash tables.
-
-# Arguments
-* `conn`:\\[in\\] A valid connectivity.
-* `treeid`:\\[in\\] The original tree index for this coordinate tuple.
-* `coords`:\\[in\\] A valid coordinate 2-tuple relative to *treeid*.
-* `treeid_out`:\\[out\\] The lowest tree index touching the coordinate.
-* `coords_out`:\\[out\\] The input coordinates, if necessary after transformation into the system of the lowest numbered tree, returned in *treeid_out*.
-### Prototype
-```c
-void p4est_connectivity_coordinates_canonicalize (p4est_connectivity_t *conn, p4est_topidx_t treeid, const p4est_qcoord_t coords[], p4est_topidx_t *treeid_out, p4est_qcoord_t coords_out[]);
-```
-"""
-function p4est_connectivity_coordinates_canonicalize(conn, treeid, coords, treeid_out, coords_out)
-    @ccall libp4est.p4est_connectivity_coordinates_canonicalize(conn::Ptr{p4est_connectivity_t}, treeid::p4est_topidx_t, coords::Ptr{p4est_qcoord_t}, treeid_out::Ptr{p4est_topidx_t}, coords_out::Ptr{p4est_qcoord_t})::Cvoid
 end
 
 """
@@ -6595,7 +10277,7 @@ Fills an array with information about corner neighbors.
 * `connectivity`:\\[in\\] Connectivity structure.
 * `itree`:\\[in\\] The number of the originating tree.
 * `icorner`:\\[in\\] The number of the originating corner.
-* `ci`:\\[in,out\\] A [`p4est_corner_info_t`](@ref) structure with initialized array.
+* `ci`:\\[in,out\\] A `p4est_corner_info_t` structure with initialized array.
 ### Prototype
 ```c
 void p4est_find_corner_transform (p4est_connectivity_t * connectivity, p4est_topidx_t itree, int icorner, p4est_corner_info_t * ci);
@@ -7152,30 +10834,6 @@ function p8est_connectivity_get_neighbor_transforms(conn, tree_id, boundary_type
 end
 
 """
-    p8est_connectivity_coordinates_canonicalize(conn, treeid, coords, treeid_out, coords_out)
-
-Determine the owning tree for a coordinate and transform it there.
-
-On a boundary between trees, different coordinate systems meet. A coordinate on a tree boundary face, edge, or corner generated from the perspective of a specific tree may be transformed into any other touching tree's coordinate system and still refer to the same point in the mesh.
-
-To uniquely identify a coordinate, this function identifies the lowest numbered tree touching this coordinate and transforms the coordinate into that system. The result can be used e. g. in topology hash tables.
-
-# Arguments
-* `conn`:\\[in\\] A valid connectivity.
-* `treeid`:\\[in\\] The original tree index for this coordinate tuple.
-* `coords`:\\[in\\] A valid coordinate 2-tuple relative to *treeid*.
-* `treeid_out`:\\[out\\] The lowest tree index touching the coordinate.
-* `coords_out`:\\[out\\] The input coordinates, if necessary after transformation into the system of the lowest numbered tree, returned in *treeid_out*.
-### Prototype
-```c
-void p8est_connectivity_coordinates_canonicalize (p8est_connectivity_t *conn, p4est_topidx_t treeid, const p4est_qcoord_t coords[], p4est_topidx_t *treeid_out, p4est_qcoord_t coords_out[]);
-```
-"""
-function p8est_connectivity_coordinates_canonicalize(conn, treeid, coords, treeid_out, coords_out)
-    @ccall libp4est.p8est_connectivity_coordinates_canonicalize(conn::Ptr{p8est_connectivity_t}, treeid::p4est_topidx_t, coords::Ptr{p4est_qcoord_t}, treeid_out::Ptr{p4est_topidx_t}, coords_out::Ptr{p4est_qcoord_t})::Cvoid
-end
-
-"""
     p8est_connectivity_face_neighbor_corner_set(c, f, nf, set)
 
 Transform a corner across one of the adjacent faces into a neighbor tree. It expects a face permutation index that has been precomputed.
@@ -7680,20 +11338,6 @@ function p8est_connectivity_new_rotcubes()
 end
 
 """
-    p8est_connectivity_new_pillow()
-
-Create a connectivity structure for two trees on top of each other. This connectivity is meant to be used with p8est_geometry_new_pillow to map a spherical shell.
-
-### Prototype
-```c
-p8est_connectivity_t *p8est_connectivity_new_pillow (void);
-```
-"""
-function p8est_connectivity_new_pillow()
-    @ccall libp4est.p8est_connectivity_new_pillow()::Ptr{p8est_connectivity_t}
-end
-
-"""
     p8est_connectivity_new_brick(m, n, p, periodic_a, periodic_b, periodic_c)
 
 An m by n by p array with periodicity in x, y, and z if periodic\\_a, periodic\\_b, and periodic\\_c are true, respectively.
@@ -7845,7 +11489,7 @@ Fills an array with information about edge neighbors.
 * `connectivity`:\\[in\\] Connectivity structure.
 * `itree`:\\[in\\] The number of the originating tree.
 * `iedge`:\\[in\\] The number of the originating edge.
-* `ei`:\\[in,out\\] A [`p8est_edge_info_t`](@ref) structure with initialized array.
+* `ei`:\\[in,out\\] A `p8est_edge_info_t` structure with initialized array.
 ### Prototype
 ```c
 void p8est_find_edge_transform (p8est_connectivity_t * connectivity, p4est_topidx_t itree, int iedge, p8est_edge_info_t * ei);
@@ -7864,7 +11508,7 @@ Fills an array with information about corner neighbors.
 * `connectivity`:\\[in\\] Connectivity structure.
 * `itree`:\\[in\\] The number of the originating tree.
 * `icorner`:\\[in\\] The number of the originating corner.
-* `ci`:\\[in,out\\] A [`p8est_corner_info_t`](@ref) structure with initialized array.
+* `ci`:\\[in,out\\] A `p8est_corner_info_t` structure with initialized array.
 ### Prototype
 ```c
 void p8est_find_corner_transform (p8est_connectivity_t * connectivity, p4est_topidx_t itree, int icorner, p8est_corner_info_t * ci);
@@ -7967,7 +11611,7 @@ end
 
 ### Prototype
 ```c
-static inline p8est_edge_transform_t * p8est_edge_array_index (sc_array_t *array, size_t it);
+static inline p8est_edge_transform_t * p8est_edge_array_index (sc_array_t * array, size_t it);
 ```
 """
 function p8est_edge_array_index(array, it)
@@ -7979,7 +11623,7 @@ end
 
 ### Prototype
 ```c
-static inline p8est_corner_transform_t * p8est_corner_array_index (sc_array_t *array, size_t it);
+static inline p8est_corner_transform_t * p8est_corner_array_index (sc_array_t * array, size_t it);
 ```
 """
 function p8est_corner_array_index(array, it)
@@ -8471,15 +12115,15 @@ function t8_cmesh_new_long_brick_pyramid(comm, num_cubes)
 end
 
 """
-    t8_cmesh_new_row_of_cubes(num_trees, set_attributes, do_partition, comm, package_id)
+    t8_cmesh_new_row_of_cubes(num_trees, set_attributes, do_partition, comm)
 
 ### Prototype
 ```c
-t8_cmesh_t t8_cmesh_new_row_of_cubes (t8_locidx_t num_trees, const int set_attributes, const int do_partition, sc_MPI_Comm comm, const int package_id);
+t8_cmesh_t t8_cmesh_new_row_of_cubes (t8_locidx_t num_trees, const int set_attributes, const int do_partition, sc_MPI_Comm comm);
 ```
 """
-function t8_cmesh_new_row_of_cubes(num_trees, set_attributes, do_partition, comm, package_id)
-    @ccall libt8.t8_cmesh_new_row_of_cubes(num_trees::t8_locidx_t, set_attributes::Cint, do_partition::Cint, comm::MPI_Comm, package_id::Cint)::t8_cmesh_t
+function t8_cmesh_new_row_of_cubes(num_trees, set_attributes, do_partition, comm)
+    @ccall libt8.t8_cmesh_new_row_of_cubes(num_trees::t8_locidx_t, set_attributes::Cint, do_partition::Cint, comm::MPI_Comm)::t8_cmesh_t
 end
 
 """
@@ -8591,9 +12235,28 @@ function t8_cmesh_new_cubed_sphere(radius, comm)
 end
 
 """
+    t8_cmesh_get_tree_geom_hash(cmesh, gtreeid)
+
+Get the hash of the geometry stored for a tree in a cmesh.
+
+# Arguments
+* `cmesh`:\\[in\\] A committed cmesh.
+* `gtreeid`:\\[in\\] A global tree in *cmesh*.
+# Returns
+The hash of the tree's geometry or if only one geometry exists, its hash.
+### Prototype
+```c
+size_t t8_cmesh_get_tree_geom_hash (t8_cmesh_t cmesh, t8_gloidx_t gtreeid);
+```
+"""
+function t8_cmesh_get_tree_geom_hash(cmesh, gtreeid)
+    @ccall libt8.t8_cmesh_get_tree_geom_hash(cmesh::t8_cmesh_t, gtreeid::t8_gloidx_t)::Csize_t
+end
+
+"""
     t8_cmesh_set_join_by_vertices(cmesh, ntrees, eclasses, vertices, connectivity, do_both_directions)
 
-Sets the face connectivity information of an un-committed cmesh based on a list of tree vertices.
+Sets the face connectivity information of an un-committed  based on a list of tree vertices.
 
 !!! warning
 
@@ -8622,7 +12285,7 @@ end
 """
     t8_cmesh_set_join_by_stash(cmesh, connectivity, do_both_directions)
 
-Sets the face connectivity information of an un-committed cmesh based on the cmesh stash.
+Sets the face connectivity information of an un-committed  based on the cmesh stash.
 
 !!! warning
 
@@ -8646,96 +12309,1655 @@ function t8_cmesh_set_join_by_stash(cmesh, connectivity, do_both_directions)
 end
 
 """
+    t8_offset_first(proc, offset)
+
+Return the global id of the first local tree of a given process in a partition.
+
+# Arguments
+* `proc`:\\[in\\] The rank of the process.
+* `offset`:\\[in\\] The partition table.
+# Returns
+The global id of the first local tree of *proc* in the partition *offset*.
+### Prototype
+```c
+t8_gloidx_t t8_offset_first (const int proc, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_first(proc, offset)
+    @ccall libt8.t8_offset_first(proc::Cint, offset::Ptr{t8_gloidx_t})::t8_gloidx_t
+end
+
+"""
+    t8_offset_first_tree_to_entry(first_tree, shared)
+
+Given the global tree id of the first local tree of a process and the flag whether it is shared or not, compute the entry in the offset array. This entry is the first\\_tree if it is not shared and -first\\_tree - 1 if it is shared.
+
+# Arguments
+* `first_tree`:\\[in\\] The global tree id of a process's first tree.
+* `shared`:\\[in\\] 0 if *first_tree* is not shared with a smaller rank, 1 if it is.
+# Returns
+The entry that represents the process in an offset array. *first_tree* if *shared* == 0 - *first_tree* - 1 if *shared* != 0
+### Prototype
+```c
+t8_gloidx_t t8_offset_first_tree_to_entry (const t8_gloidx_t first_tree, const int shared);
+```
+"""
+function t8_offset_first_tree_to_entry(first_tree, shared)
+    @ccall libt8.t8_offset_first_tree_to_entry(first_tree::t8_gloidx_t, shared::Cint)::t8_gloidx_t
+end
+
+"""
+    t8_offset_num_trees(proc, offset)
+
+The number of trees of a given process in a partition.
+
+# Arguments
+* `proc`:\\[in\\] A mpi rank.
+* `offset`:\\[in\\] A partition table.
+# Returns
+The number of local trees of *proc* in the partition *offset*.
+### Prototype
+```c
+t8_gloidx_t t8_offset_num_trees (const int proc, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_num_trees(proc, offset)
+    @ccall libt8.t8_offset_num_trees(proc::Cint, offset::Ptr{t8_gloidx_t})::t8_gloidx_t
+end
+
+"""
+    t8_offset_last(proc, offset)
+
+Return the last local tree of a given process in a partition.
+
+# Arguments
+* `proc`:\\[in\\] A mpi rank.
+* `offset`:\\[in\\] A partition table.
+# Returns
+The global tree id of the last local tree of *proc* in *offset*.
+### Prototype
+```c
+t8_gloidx_t t8_offset_last (const int proc, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_last(proc, offset)
+    @ccall libt8.t8_offset_last(proc::Cint, offset::Ptr{t8_gloidx_t})::t8_gloidx_t
+end
+
+"""
+    t8_offset_empty(proc, offset)
+
+Check whether a given process has no local trees in a given partition.
+
+# Arguments
+* `proc`:\\[in\\] A mpi rank.
+* `offset`:\\[in\\] A partition table.
+# Returns
+nonzero if *proc* does not have local trees in *offset*. 0 otherwise.
+### Prototype
+```c
+int t8_offset_empty (const int proc, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_empty(proc, offset)
+    @ccall libt8.t8_offset_empty(proc::Cint, offset::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_next_nonempty_rank(rank, mpisize, offset)
+
+Find the next higher rank that is not empty. returns mpisize if this rank does not exist.
+
+# Arguments
+* `proc`:\\[in\\] An MPI rank.
+* `mpisize`:\\[in\\] The number of total MPI ranks.
+* `offset`:\\[in\\] An array with at least *mpisize* + 1 entries.
+# Returns
+A rank *p* such that *p* > *rank* and [`t8_offset_empty`](@ref) (*p*, *offset*) is True and [`t8_offset_empty`](@ref) (*q*, *offset*) is False for all *rank* < *q* < *p*. If no such *q* exists, *mpisize* is returned.
+### Prototype
+```c
+int t8_offset_next_nonempty_rank (const int rank, const int mpisize, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_next_nonempty_rank(rank, mpisize, offset)
+    @ccall libt8.t8_offset_next_nonempty_rank(rank::Cint, mpisize::Cint, offset::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_in_range(tree_id, proc, offset)
+
+Determine whether a given global tree id is a local tree of a given process in a certain partition.
+
+# Arguments
+* `tree_id`:\\[in\\] A global tree id.
+* `proc`:\\[in\\] A mpi rank.
+* `offset`:\\[in\\] A partition table.
+# Returns
+nonzero if *tree_id* is a local tree of *proc* in *offset*. 0 if it is not.
+### Prototype
+```c
+int t8_offset_in_range (const t8_gloidx_t tree_id, const int proc, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_in_range(tree_id, proc, offset)
+    @ccall libt8.t8_offset_in_range(tree_id::t8_gloidx_t, proc::Cint, offset::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_any_owner_of_tree(mpisize, gtree, offset)
+
+Find any process that has a given tree as local tree.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+# Returns
+An MPI rank that has *gtree* as a local tree.
+### Prototype
+```c
+int t8_offset_any_owner_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_any_owner_of_tree(mpisize, gtree, offset)
+    @ccall libt8.t8_offset_any_owner_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_any_owner_of_tree_ext(mpisize, start_proc, gtree, offset)
+
+Find any process that has a given tree as local tree.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `start_proc`:\\[in\\] The mpirank to start the search with.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+# Returns
+An MPI rank that has *gtree* as a local tree.
+### Prototype
+```c
+int t8_offset_any_owner_of_tree_ext (const int mpisize, const int start_proc, const t8_gloidx_t gtree, const t8_gloidx_t *offset);
+```
+"""
+function t8_offset_any_owner_of_tree_ext(mpisize, start_proc, gtree, offset)
+    @ccall libt8.t8_offset_any_owner_of_tree_ext(mpisize::Cint, start_proc::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_first_owner_of_tree(mpisize, gtree, offset, some_owner)
+
+Find the smallest process that has a given tree as local tree. To increase the runtime, an arbitrary process having this tree as local tree can be passed as an argument. Otherwise, such an owner is computed during the call.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+* `some_owner`:\\[in\\] If >= 0 considered as input: a process that has *gtree* as local tree. If < 0 on output a process that has *gtree* as local tree. Specifying *some_owner* increases the runtime from O(log mpisize) to O(n), where n is the number of owners of the tree.
+# Returns
+The smallest rank that has *gtree* as a local tree.
+### Prototype
+```c
+int t8_offset_first_owner_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset, int *some_owner);
+```
+"""
+function t8_offset_first_owner_of_tree(mpisize, gtree, offset, some_owner)
+    @ccall libt8.t8_offset_first_owner_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t}, some_owner::Ptr{Cint})::Cint
+end
+
+"""
+    t8_offset_last_owner_of_tree(mpisize, gtree, offset, some_owner)
+
+Find the biggest process that has a given tree as local tree. To increase the runtime, an arbitrary process having this tree as local tree can be passed as an argument. Otherwise, such an owner is computed during the call.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+* `some_owner`:\\[in,out\\] If >= 0 considered as input: a process that has *gtree* as local tree. If < 0 on output a process that has *gtree* as local tree. Specifying *some_owner* increases the runtime from O(log mpisize) to O(n), where n is the number of owners of the tree.
+# Returns
+The biggest rank that has *gtree* as a local tree.
+### Prototype
+```c
+int t8_offset_last_owner_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset, int *some_owner);
+```
+"""
+function t8_offset_last_owner_of_tree(mpisize, gtree, offset, some_owner)
+    @ccall libt8.t8_offset_last_owner_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t}, some_owner::Ptr{Cint})::Cint
+end
+
+"""
+    t8_offset_next_owner_of_tree(mpisize, gtree, offset, current_owner)
+
+Given a process current\\_owner that has the tree gtree as local tree, find the next bigger rank that also has this tree as local tree.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+* `current_owner`:\\[in\\] A process that has *gtree* as local tree.
+# Returns
+The MPI rank of the next bigger rank than *current_owner* that has *gtree* as local tree. -1 if non such rank exists.
+### Prototype
+```c
+int t8_offset_next_owner_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset, int current_owner);
+```
+"""
+function t8_offset_next_owner_of_tree(mpisize, gtree, offset, current_owner)
+    @ccall libt8.t8_offset_next_owner_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t}, current_owner::Cint)::Cint
+end
+
+"""
+    t8_offset_prev_owner_of_tree(mpisize, gtree, offset, current_owner)
+
+Given a process current\\_owner that has the tree gtree as local tree, find the next smaller rank that also has this tree as local tree.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global id of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+* `current_owner`:\\[in\\] A process that has *gtree* as local tree.
+# Returns
+The MPI rank of the next smaller rank than *current_owner* that has *gtree* as local tree. -1 if non such rank exists.
+### Prototype
+```c
+int t8_offset_prev_owner_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset, const int current_owner);
+```
+"""
+function t8_offset_prev_owner_of_tree(mpisize, gtree, offset, current_owner)
+    @ccall libt8.t8_offset_prev_owner_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t}, current_owner::Cint)::Cint
+end
+
+"""
+    t8_offset_all_owners_of_tree(mpisize, gtree, offset, owners)
+
+Compute a list of all processes that own a specific tree.n *offset* minus 1.
+
+# Arguments
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `gtree`:\\[in\\] The global index of a tree.
+* `offset`:\\[in\\] The partition to be considered.
+* `owners`:\\[in,out\\] On input an initialized [`sc_array`](@ref) with integer entries and zero elements. On output a sorted list of all MPI ranks that have *gtree* as a local tree in *offset*.
+### Prototype
+```c
+void t8_offset_all_owners_of_tree (const int mpisize, const t8_gloidx_t gtree, const t8_gloidx_t *offset, sc_array_t *owners);
+```
+"""
+function t8_offset_all_owners_of_tree(mpisize, gtree, offset, owners)
+    @ccall libt8.t8_offset_all_owners_of_tree(mpisize::Cint, gtree::t8_gloidx_t, offset::Ptr{t8_gloidx_t}, owners::Ptr{sc_array_t})::Cvoid
+end
+
+"""
+    t8_offset_nosend(proc, mpisize, offset_from, offset_to)
+
+Query whether in a repartition setting a given process does send any of its local trees to any other process (including itself)
+
+# Arguments
+* `proc`:\\[in\\] A mpi rank.
+* `mpisize`:\\[in\\] The number of MPI ranks, also the number of entries in *offset* minus 1.
+* `offset_from`:\\[in\\] The partition table of the current partition.
+* `offset_to`:\\[in\\] The partition table of the next partition.
+# Returns
+nonzero if *proc* will not send any local trees if we repartition from *offset_from* to *offset_to* 0 if it does send local trees.
+### Prototype
+```c
+int t8_offset_nosend (int proc, int mpisize, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to);
+```
+"""
+function t8_offset_nosend(proc, mpisize, offset_from, offset_to)
+    @ccall libt8.t8_offset_nosend(proc::Cint, mpisize::Cint, offset_from::Ptr{t8_gloidx_t}, offset_to::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_sendsto(proca, procb, t8_offset_from, t8_offset_to)
+
+Query whether in a repartitioning setting, a given process sends local trees (and then possibly ghosts) to a given other process.
+
+# Arguments
+* `proca`:\\[in\\] Mpi rank of the possible sending process.
+* `procb`:\\[in\\] Mpi rank of the possible receiver.
+* `offset_from`:\\[in\\] The partition table of the current partition.
+* `offset_to`:\\[in\\] The partition table of the next partition.
+# Returns
+nonzero if *proca* does send local trees to *procb* when we repartition from *offset_from* to *offset_to*. 0 else.
+### Prototype
+```c
+int t8_offset_sendsto (int proca, int procb, const t8_gloidx_t *t8_offset_from, const t8_gloidx_t *t8_offset_to);
+```
+"""
+function t8_offset_sendsto(proca, procb, t8_offset_from, t8_offset_to)
+    @ccall libt8.t8_offset_sendsto(proca::Cint, procb::Cint, t8_offset_from::Ptr{t8_gloidx_t}, t8_offset_to::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_sendstree(proc_send, proc_to, gtree, offset_from, offset_to)
+
+Query whether in a repartitioning setting, a given process sends a given tree to a second process.
+
+# Arguments
+* `proc_send`:\\[in\\] Mpi rank of the possible sending process.
+* `proc_recv`:\\[in\\] Mpi rank of the possible receiver.
+* `gtree`:\\[in\\] A global tree id.
+* `offset_from`:\\[in\\] The partition table of the current partition.
+* `offset_to`:\\[in\\] The partition table of the next partition.
+# Returns
+nonzero if *proc_send* will send the tree *gtree* to *proc_recv*. 0 else. When calling, *gtree* must not be a local tree of *proc_send* in *offset_from*. In this case, 0 is always returned.
+### Prototype
+```c
+int t8_offset_sendstree (int proc_send, int proc_to, t8_gloidx_t gtree, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to);
+```
+"""
+function t8_offset_sendstree(proc_send, proc_to, gtree, offset_from, offset_to)
+    @ccall libt8.t8_offset_sendstree(proc_send::Cint, proc_to::Cint, gtree::t8_gloidx_t, offset_from::Ptr{t8_gloidx_t}, offset_to::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_range_send(start, _end, mpirank, offset_from, offset_to)
+
+Count the number of processes in a given range [a,b] that send to a given other process in a repartitioning setting.
+
+# Arguments
+* `start`:\\[in\\] The first mpi rank to be considered as sender.
+* `end`:\\[in\\] The last mpi rank to be considered as sender.
+* `mpirank`:\\[in\\] The mpirank to be considered as receiver.
+* `offset_from`:\\[in\\] The partition table of the current partition.
+* `offset_to`:\\[in\\] The partition table of the next partition.
+# Returns
+The number of processes p, such that *start* <= p <= *end* and p does send local trees (and possibly ghosts) to *mpirank*.
+### Prototype
+```c
+int t8_offset_range_send (int start, int end, int mpirank, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to);
+```
+"""
+function t8_offset_range_send(start, _end, mpirank, offset_from, offset_to)
+    @ccall libt8.t8_offset_range_send(start::Cint, _end::Cint, mpirank::Cint, offset_from::Ptr{t8_gloidx_t}, offset_to::Ptr{t8_gloidx_t})::Cint
+end
+
+"""
+    t8_offset_print(offset, comm)
+
+### Prototype
+```c
+void t8_offset_print (t8_shmem_array_t offset, sc_MPI_Comm comm);
+```
+"""
+function t8_offset_print(offset, comm)
+    @ccall libt8.t8_offset_print(offset::t8_shmem_array_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_partition(cmesh, comm)
+
+### Prototype
+```c
+void t8_cmesh_partition (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_partition(cmesh, comm)
+    @ccall libt8.t8_cmesh_partition(cmesh::t8_cmesh_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_gather_trees_per_eclass(cmesh, comm)
+
+### Prototype
+```c
+void t8_cmesh_gather_trees_per_eclass (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_gather_trees_per_eclass(cmesh, comm)
+    @ccall libt8.t8_cmesh_gather_trees_per_eclass(cmesh::t8_cmesh_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_gather_treecount(cmesh, comm)
+
+### Prototype
+```c
+void t8_cmesh_gather_treecount (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_gather_treecount(cmesh, comm)
+    @ccall libt8.t8_cmesh_gather_treecount(cmesh::t8_cmesh_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_gather_treecount_nocommit(cmesh, comm)
+
+### Prototype
+```c
+void t8_cmesh_gather_treecount_nocommit (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_gather_treecount_nocommit(cmesh, comm)
+    @ccall libt8.t8_cmesh_gather_treecount_nocommit(cmesh::t8_cmesh_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_offset_print(cmesh, comm)
+
+### Prototype
+```c
+void t8_cmesh_offset_print (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_offset_print(cmesh, comm)
+    @ccall libt8.t8_cmesh_offset_print(cmesh::t8_cmesh_t, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_offset_concentrate(proc, comm, num_trees)
+
+### Prototype
+```c
+t8_shmem_array_t t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm, t8_gloidx_t num_trees);
+```
+"""
+function t8_cmesh_offset_concentrate(proc, comm, num_trees)
+    @ccall libt8.t8_cmesh_offset_concentrate(proc::Cint, comm::MPI_Comm, num_trees::t8_gloidx_t)::t8_shmem_array_t
+end
+
+"""
+    t8_cmesh_offset_random(comm, num_trees, shared, seed)
+
+### Prototype
+```c
+t8_shmem_array_t t8_cmesh_offset_random (sc_MPI_Comm comm, t8_gloidx_t num_trees, int shared, unsigned seed);
+```
+"""
+function t8_cmesh_offset_random(comm, num_trees, shared, seed)
+    @ccall libt8.t8_cmesh_offset_random(comm::MPI_Comm, num_trees::t8_gloidx_t, shared::Cint, seed::Cuint)::t8_shmem_array_t
+end
+
+"""
+    t8_cmesh_offset_half(cmesh, comm)
+
+### Prototype
+```c
+t8_shmem_array_t t8_cmesh_offset_half (t8_cmesh_t cmesh, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_offset_half(cmesh, comm)
+    @ccall libt8.t8_cmesh_offset_half(cmesh::t8_cmesh_t, comm::MPI_Comm)::t8_shmem_array_t
+end
+
+"""
+    t8_cmesh_offset_percent(cmesh, comm, percent)
+
+### Prototype
+```c
+t8_shmem_array_t t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent);
+```
+"""
+function t8_cmesh_offset_percent(cmesh, comm, percent)
+    @ccall libt8.t8_cmesh_offset_percent(cmesh::t8_cmesh_t, comm::MPI_Comm, percent::Cint)::t8_shmem_array_t
+end
+
+"""
+    t8_stash_class
+
+The eclass information that is stored before a cmesh is committed.
+
+| Field  | Note                     |
+| :----- | :----------------------- |
+| id     | The global tree id       |
+| eclass | The eclass of that tree  |
+"""
+struct t8_stash_class
+    id::t8_gloidx_t
+    eclass::t8_eclass_t
+end
+
+"""The eclass information that is stored before a cmesh is committed."""
+const t8_stash_class_struct_t = t8_stash_class
+
+"""
+    t8_stash_joinface
+
+The face-connection information that is stored before a cmesh is committed.
+
+| Field       | Note                                                                       |
+| :---------- | :------------------------------------------------------------------------- |
+| id1         | The global tree id of the first tree in the connection.                    |
+| id2         | The global tree id of the second tree. We ensure id1<=id2.                 |
+| face1       | The face number of the first of the connected faces.                       |
+| face2       | The face number of the second face.                                        |
+| orientation | The orientation of the face connection.  # See also t8\\_cmesh\\_types.h.  |
+"""
+struct t8_stash_joinface
+    id1::t8_gloidx_t
+    id2::t8_gloidx_t
+    face1::Cint
+    face2::Cint
+    orientation::Cint
+end
+
+"""The face-connection information that is stored before a cmesh is committed."""
+const t8_stash_joinface_struct_t = t8_stash_joinface
+
+"""
+    t8_stash_attribute
+
+The attribute information that is stored before a cmesh is committed. The pair (package\\_id, key) serves as a lookup key to identify the data.
+
+| Field        | Note                                                                    |
+| :----------- | :---------------------------------------------------------------------- |
+| id           | The global tree id                                                      |
+| attr\\_size  | The size (in bytes) of this attribute                                   |
+| attr\\_data  | Array of *size* bytes storing the attributes data.                      |
+| is\\_owned   | True if the data was copied, false if the data is still owned by user.  |
+| package\\_id | The id of the package that set this attribute.                          |
+| key          | The key used by the package to identify this attribute.                 |
+"""
+struct t8_stash_attribute
+    id::t8_gloidx_t
+    attr_size::Csize_t
+    attr_data::Ptr{Cvoid}
+    is_owned::Cint
+    package_id::Cint
+    key::Cint
+end
+
+"""The attribute information that is stored before a cmesh is committed. The pair (package\\_id, key) serves as a lookup key to identify the data."""
+const t8_stash_attribute_struct_t = t8_stash_attribute
+
+"""The stash data structure is used to store information about the cmesh before it is committed. In particular we store the eclasses of the trees, the face-connections and the tree attributes. Using the stash structure allows us to have a very flexible interface. When constructing a new mesh, the user can specify all these mesh entities in arbitrary order. As soon as the cmesh is committed the information is copied from the stash to the cmesh in an order mannered."""
+const t8_stash_struct_t = t8_stash
+
+"""
+    t8_stash_init(pstash)
+
+Initialize a stash data structure.
+
+# Arguments
+* `pstash`:\\[in,out\\] A pointer to the stash to be initialized.
+### Prototype
+```c
+void t8_stash_init (t8_stash_t *pstash);
+```
+"""
+function t8_stash_init(pstash)
+    @ccall libt8.t8_stash_init(pstash::Ptr{t8_stash_t})::Cvoid
+end
+
+"""
+    t8_stash_destroy(pstash)
+
+Free all memory associated in a stash structure.
+
+# Arguments
+* `pstash`:\\[in,out\\] A pointer to the stash to be destroyed. The pointer is set to NULL after the function call.
+### Prototype
+```c
+void t8_stash_destroy (t8_stash_t *pstash);
+```
+"""
+function t8_stash_destroy(pstash)
+    @ccall libt8.t8_stash_destroy(pstash::Ptr{t8_stash_t})::Cvoid
+end
+
+"""
+    t8_stash_add_class(stash, id, eclass)
+
+Set the eclass of a tree.
+
+# Arguments
+* `stash`:\\[in,out\\] The stash to be updated.
+* `id`:\\[in\\] The global id of the tree whose eclass should be set.
+* `eclass`:\\[in\\] The eclass of tree with id *id*.
+### Prototype
+```c
+void t8_stash_add_class (t8_stash_t stash, t8_gloidx_t id, t8_eclass_t eclass);
+```
+"""
+function t8_stash_add_class(stash, id, eclass)
+    @ccall libt8.t8_stash_add_class(stash::t8_stash_t, id::t8_gloidx_t, eclass::t8_eclass_t)::Cvoid
+end
+
+"""
+    t8_stash_add_facejoin(stash, gid1, gid2, face1, face2, orientation)
+
+Add a face connection to a stash.
+
+# Arguments
+* `stash`:\\[in,out\\] The stash to be updated.
+* `id1`:\\[in\\] The global id of the first tree.
+* `id2`:\\[in\\] The global id of the second tree,
+* `face1`:\\[in\\] The face number of the face of the first tree.
+* `face2`:\\[in\\] The face number of the face of the second tree.
+* `orientation`:\\[in\\] The orientation of the faces to each other.
+### Prototype
+```c
+void t8_stash_add_facejoin (t8_stash_t stash, t8_gloidx_t gid1, t8_gloidx_t gid2, int face1, int face2, int orientation);
+```
+"""
+function t8_stash_add_facejoin(stash, gid1, gid2, face1, face2, orientation)
+    @ccall libt8.t8_stash_add_facejoin(stash::t8_stash_t, gid1::t8_gloidx_t, gid2::t8_gloidx_t, face1::Cint, face2::Cint, orientation::Cint)::Cvoid
+end
+
+"""
+    t8_stash_class_sort(stash)
+
+Sort the entries in the class array by the order given in the enum definition of [`t8_eclass`](@ref).
+
+# Arguments
+* `stash`:\\[in,out\\] The stash whose class array is sorted.
+### Prototype
+```c
+void t8_stash_class_sort (t8_stash_t stash);
+```
+"""
+function t8_stash_class_sort(stash)
+    @ccall libt8.t8_stash_class_sort(stash::t8_stash_t)::Cvoid
+end
+
+"""
+    t8_stash_class_bsearch(stash, tree_id)
+
+Search for an entry with a given tree index in the class-stash. The stash must be sorted beforehand.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be searched for.
+* `tree_id`:\\[in\\] The global tree id.
+# Returns
+The index of an element in the classes array of *stash* corresponding to *tree_id*. -1 if not found.
+### Prototype
+```c
+ssize_t t8_stash_class_bsearch (t8_stash_t stash, t8_gloidx_t tree_id);
+```
+"""
+function t8_stash_class_bsearch(stash, tree_id)
+    @ccall libt8.t8_stash_class_bsearch(stash::t8_stash_t, tree_id::t8_gloidx_t)::Cssize_t
+end
+
+"""
+    t8_stash_joinface_sort(stash)
+
+Sort then entries in the facejoin array in order of the first treeid.
+
+# Arguments
+* `stash`:\\[in,out\\] The stash whose facejoin array is sorted.
+### Prototype
+```c
+void t8_stash_joinface_sort (t8_stash_t stash);
+```
+"""
+function t8_stash_joinface_sort(stash)
+    @ccall libt8.t8_stash_joinface_sort(stash::t8_stash_t)::Cvoid
+end
+
+"""
+    t8_stash_add_attribute(stash, id, package_id, key, size, attr, copy)
+
+Add an attribute to a tree.
+
+# Arguments
+* `stash`:\\[in\\] The stash structure to be modified.
+* `id`:\\[in\\] The global index of the tree to which the attribute is added.
+* `package_id`:\\[in\\] The unique id of the current package.
+* `key`:\\[in\\] An integer value used to identify this attribute.
+* `size`:\\[in\\] The size (in bytes) of the attribute.
+* `attr`:\\[in\\] Points to *size* bytes of memory that should be stored as the attribute.
+* `copy`:\\[in\\] If true the attribute data is copied from *attr* to an internal storage. If false only the pointer *attr* is stored and the data is only copied if the cmesh is committed. (More memory efficient).
+### Prototype
+```c
+void t8_stash_add_attribute (t8_stash_t stash, t8_gloidx_t id, int package_id, int key, size_t size, void *const attr, int copy);
+```
+"""
+function t8_stash_add_attribute(stash, id, package_id, key, size, attr, copy)
+    @ccall libt8.t8_stash_add_attribute(stash::t8_stash_t, id::t8_gloidx_t, package_id::Cint, key::Cint, size::Csize_t, attr::Ptr{Cvoid}, copy::Cint)::Cvoid
+end
+
+"""
+    t8_stash_get_attribute_size(stash, index)
+
+Return the size (in bytes) of an attribute in the stash.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+The size in bytes of the attribute.
+### Prototype
+```c
+size_t t8_stash_get_attribute_size (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_get_attribute_size(stash, index)
+    @ccall libt8.t8_stash_get_attribute_size(stash::t8_stash_t, index::Csize_t)::Csize_t
+end
+
+"""
+    t8_stash_get_attribute(stash, index)
+
+Return the pointer to an attribute in the stash.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+A void pointer to the memory region where the attribute is stored.
+### Prototype
+```c
+void * t8_stash_get_attribute (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_get_attribute(stash, index)
+    @ccall libt8.t8_stash_get_attribute(stash::t8_stash_t, index::Csize_t)::Ptr{Cvoid}
+end
+
+"""
+    t8_stash_get_attribute_tree_id(stash, index)
+
+Return the id of the tree a given attribute belongs to.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+The tree id.
+### Prototype
+```c
+t8_gloidx_t t8_stash_get_attribute_tree_id (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_get_attribute_tree_id(stash, index)
+    @ccall libt8.t8_stash_get_attribute_tree_id(stash::t8_stash_t, index::Csize_t)::t8_gloidx_t
+end
+
+"""
+    t8_stash_get_attribute_key(stash, index)
+
+Return the key of a given attribute.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+The attribute's key.
+### Prototype
+```c
+int t8_stash_get_attribute_key (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_get_attribute_key(stash, index)
+    @ccall libt8.t8_stash_get_attribute_key(stash::t8_stash_t, index::Csize_t)::Cint
+end
+
+"""
+    t8_stash_get_attribute_id(stash, index)
+
+Return the package\\_id of a given attribute.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+The attribute's package\\_id.
+### Prototype
+```c
+int t8_stash_get_attribute_id (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_get_attribute_id(stash, index)
+    @ccall libt8.t8_stash_get_attribute_id(stash::t8_stash_t, index::Csize_t)::Cint
+end
+
+"""
+    t8_stash_attribute_is_owned(stash, index)
+
+Return true if an attribute in the stash is owned by the stash, that is, it was copied in the call to [`t8_stash_add_attribute`](@ref). Returns false if the attribute is not owned by the stash.
+
+# Arguments
+* `stash`:\\[in\\] The stash to be considered.
+* `index`:\\[in\\] The index of the attribute in the attribute array of *stash*.
+# Returns
+True of false.
+### Prototype
+```c
+int t8_stash_attribute_is_owned (t8_stash_t stash, size_t index);
+```
+"""
+function t8_stash_attribute_is_owned(stash, index)
+    @ccall libt8.t8_stash_attribute_is_owned(stash::t8_stash_t, index::Csize_t)::Cint
+end
+
+"""
+    t8_stash_attribute_sort(stash)
+
+Sort the attributes array of a stash in the order (treeid, package_id, key) *
+
+# Arguments
+* `stash`:\\[in,out\\] The stash to be considered.
+### Prototype
+```c
+void t8_stash_attribute_sort (t8_stash_t stash);
+```
+"""
+function t8_stash_attribute_sort(stash)
+    @ccall libt8.t8_stash_attribute_sort(stash::t8_stash_t)::Cvoid
+end
+
+"""
+    t8_stash_bcast(stash, root, comm, elem_counts)
+
+### Prototype
+```c
+t8_stash_t t8_stash_bcast (t8_stash_t stash, int root, sc_MPI_Comm comm, const size_t elem_counts[3]);
+```
+"""
+function t8_stash_bcast(stash, root, comm, elem_counts)
+    @ccall libt8.t8_stash_bcast(stash::t8_stash_t, root::Cint, comm::MPI_Comm, elem_counts::Ptr{Csize_t})::t8_stash_t
+end
+
+"""
+    t8_stash_is_equal(stash_a, stash_b)
+
+Check two stashes for equal content and return true if so.
+
+# Arguments
+* `stash_a`:\\[in\\] The first stash to be considered.
+* `stash_b`:\\[in\\] The first stash to be considered.
+# Returns
+True if both stashes hold copies of the same data. False otherwise.
+### Prototype
+```c
+int t8_stash_is_equal (t8_stash_t stash_a, t8_stash_t stash_b);
+```
+"""
+function t8_stash_is_equal(stash_a, stash_b)
+    @ccall libt8.t8_stash_is_equal(stash_a::t8_stash_t, stash_b::t8_stash_t)::Cint
+end
+
+"""
+    t8_attribute_info
+
+This structure holds the information associated to an attribute of a tree. The attributes of each are stored in a key-value storage, where the key consists of the two entries (package\\_id,key) both being integers. The package\\_id serves to identify the application layer that added the attribute and the key identifies the attribute within that application layer.
+
+All attribute info objects of one tree are stored in an array and adding a tree's att\\_offset entry to the tree's address yields this array. The attributes themselves are stored in an array directly behind the array of the attribute infos.
+"""
+struct t8_attribute_info
+    package_id::Cint
+    key::Cint
+    attribute_offset::Csize_t
+    attribute_size::Csize_t
+end
+
+"""
+This structure holds the information associated to an attribute of a tree. The attributes of each are stored in a key-value storage, where the key consists of the two entries (package\\_id,key) both being integers. The package\\_id serves to identify the application layer that added the attribute and the key identifies the attribute within that application layer.
+
+All attribute info objects of one tree are stored in an array and adding a tree's att\\_offset entry to the tree's address yields this array. The attributes themselves are stored in an array directly behind the array of the attribute infos.
+"""
+const t8_attribute_info_struct_t = t8_attribute_info
+
+"""
+    t8_trees_glo_lo_hash_t
+
+This struct is an entry of the trees global\\_id to local\\_id hash table for ghost trees.
+
+| Field       | Note           |
+| :---------- | :------------- |
+| global\\_id | The global id  |
+| local\\_id  | The local id   |
+"""
+struct t8_trees_glo_lo_hash_t
+    global_id::t8_gloidx_t
+    local_id::t8_locidx_t
+end
+
+"""
+    t8_cmesh_trees_init(ptrees, num_procs, num_trees, num_ghosts)
+
+Initialize a trees structure and allocate its parts. This function allocates the from\\_procs array without filling it, it also allocates the tree\\_to\\_proc and ghost\\_to\\_proc arrays. No memory for trees or ghosts is allocated.
+
+# Arguments
+* `[in,ou`: ptrees The trees structure to be initialized.
+* `num_procs`:\\[in\\] The number of entries of its from\\_proc array (can be different for each process).
+* `num_trees`:\\[in\\] The number of trees that will be stored in this structure.
+* `num_ghosts`:\\[in\\] The number of ghosts that will be stored in this structure.
+### Prototype
+```c
+void t8_cmesh_trees_init (t8_cmesh_trees_t *ptrees, int num_procs, t8_locidx_t num_trees, t8_locidx_t num_ghosts);
+```
+"""
+function t8_cmesh_trees_init(ptrees, num_procs, num_trees, num_ghosts)
+    @ccall libt8.t8_cmesh_trees_init(ptrees::Ptr{t8_cmesh_trees_t}, num_procs::Cint, num_trees::t8_locidx_t, num_ghosts::t8_locidx_t)::Cvoid
+end
+
+struct t8_part_tree
+    first_tree::Cstring
+    first_tree_id::t8_locidx_t
+    first_ghost_id::t8_locidx_t
+    num_trees::t8_locidx_t
+    num_ghosts::t8_locidx_t
+end
+
+"""
+` t8_cmesh_types.h`
+
+We define here the datatypes needed for internal cmesh routines.
+"""
+const t8_part_tree_t = Ptr{t8_part_tree}
+
+"""
+    t8_cmesh_trees_get_part(trees, proc)
+
+Return one part of a specified tree array.
+
+# Arguments
+* `trees`:\\[in\\] The tree array to be queried
+* `proc`:\\[in\\] An index specifying the part to be returned.
+# Returns
+The part number *proc* of *trees*.
+### Prototype
+```c
+t8_part_tree_t t8_cmesh_trees_get_part (const t8_cmesh_trees_t trees, const int proc);
+```
+"""
+function t8_cmesh_trees_get_part(trees, proc)
+    @ccall libt8.t8_cmesh_trees_get_part(trees::t8_cmesh_trees_t, proc::Cint)::t8_part_tree_t
+end
+
+"""
+    t8_cmesh_trees_start_part(trees, proc, lfirst_tree, num_trees, lfirst_ghost, num_ghosts, alloc)
+
+Allocate the first\\_tree array of a given tree\\_part in a tree struct with a given number of trees and ghosts. This function allocates the memory for the trees and the ghosts but not for their face neighbor entries or attributes. These must be allocated later when the eclasses of the trees and ghosts are known t8_cmesh_trees_finish_part.
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure to be updated.
+* `proc`:\\[in\\] The index of the part to be updated.
+* `lfirst_tree`:\\[in\\] The local id of the first tree of that part.
+* `num_trees`:\\[in\\] The number of trees of that part.
+* `lfirst_ghost`:\\[in\\] The local id of the first ghost of that part.
+* `num_ghosts`:\\[in\\] The number of ghosts of that part.
+* `alloc`:\\[in\\] If true then the first\\_tree array is allocated for the number of trees and ghosts. When a cmesh is copied we do not want this, so in we pass alloc = 0 then.
+### Prototype
+```c
+void t8_cmesh_trees_start_part (t8_cmesh_trees_t trees, int proc, t8_locidx_t lfirst_tree, t8_locidx_t num_trees, t8_locidx_t lfirst_ghost, t8_locidx_t num_ghosts, int alloc);
+```
+"""
+function t8_cmesh_trees_start_part(trees, proc, lfirst_tree, num_trees, lfirst_ghost, num_ghosts, alloc)
+    @ccall libt8.t8_cmesh_trees_start_part(trees::t8_cmesh_trees_t, proc::Cint, lfirst_tree::t8_locidx_t, num_trees::t8_locidx_t, lfirst_ghost::t8_locidx_t, num_ghosts::t8_locidx_t, alloc::Cint)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_finish_part(trees, proc)
+
+After all classes of trees and ghosts have been set and after the number of tree attributes was set and their total size (per tree) stored temporarily in the att\\_offset variable we grow the part array by the needed amount of memory and set the offsets appropriately. The workflow should be: call t8_cmesh_trees_start_part, set tree and ghost classes manually via t8_cmesh_trees_add_tree and t8_cmesh_trees_add_ghost, call t8_cmesh_trees_init_attributes, then call this function. Afterwards successively call t8_cmesh_trees_add_attribute for each attribute and also set all face neighbors (TODO: write function).
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure to be updated.
+* `proc`:\\[in\\] The number of the part to be finished.
+### Prototype
+```c
+void t8_cmesh_trees_finish_part (t8_cmesh_trees_t trees, int proc);
+```
+"""
+function t8_cmesh_trees_finish_part(trees, proc)
+    @ccall libt8.t8_cmesh_trees_finish_part(trees::t8_cmesh_trees_t, proc::Cint)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_copy_toproc(trees_dest, trees_src, lnum_trees, lnum_ghosts)
+
+Copy the tree\\_to\\_proc and ghost\\_to\\_proc arrays of one tree structure to another one.
+
+# Arguments
+* `trees_dest`:\\[in,out\\] The destination trees structure.
+* `trees_src`:\\[in\\] The source trees structure.
+* `lnum_trees`:\\[in\\] The total number of trees stored in *trees_src*.
+* `lnum_ghosts`:\\[in\\] The total number of ghosts stored in *trees_src*.
+### Prototype
+```c
+void t8_cmesh_trees_copy_toproc (t8_cmesh_trees_t trees_dest, t8_cmesh_trees_t trees_src, t8_locidx_t lnum_trees, t8_locidx_t lnum_ghosts);
+```
+"""
+function t8_cmesh_trees_copy_toproc(trees_dest, trees_src, lnum_trees, lnum_ghosts)
+    @ccall libt8.t8_cmesh_trees_copy_toproc(trees_dest::t8_cmesh_trees_t, trees_src::t8_cmesh_trees_t, lnum_trees::t8_locidx_t, lnum_ghosts::t8_locidx_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_copy_part(trees_dest, part_dest, trees_src, part_src)
+
+Copy the trees array from one part to another.
+
+# Arguments
+* `trees_dest`:\\[in,out\\] The trees struct of the destination part.
+* `part_dest`:\\[in\\] The index of the destination part. Must be initialized by t8_cmesh_trees_start_part with alloc = 0.
+* `trees_src`:\\[in\\] The trees struct of the source part.
+* `part_src`:\\[in\\] The index of the destination part. Must be a valid part, thus t8_cmesh_trees_finish_part must have been called.
+### Prototype
+```c
+void t8_cmesh_trees_copy_part (t8_cmesh_trees_t trees_dest, int part_dest, t8_cmesh_trees_t trees_src, int part_src);
+```
+"""
+function t8_cmesh_trees_copy_part(trees_dest, part_dest, trees_src, part_src)
+    @ccall libt8.t8_cmesh_trees_copy_part(trees_dest::t8_cmesh_trees_t, part_dest::Cint, trees_src::t8_cmesh_trees_t, part_src::Cint)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_add_tree(trees, ltree_id, proc, eclass)
+
+Add a tree to a trees structure.
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure to be updated.
+* `tree_id`:\\[in\\] The local id of the tree to be inserted.
+* `proc`:\\[in\\] The mpirank of the process from which the tree was received.
+* `eclass`:\\[in\\] The tree's element class.
+### Prototype
+```c
+void t8_cmesh_trees_add_tree (t8_cmesh_trees_t trees, t8_locidx_t ltree_id, int proc, t8_eclass_t eclass);
+```
+"""
+function t8_cmesh_trees_add_tree(trees, ltree_id, proc, eclass)
+    @ccall libt8.t8_cmesh_trees_add_tree(trees::t8_cmesh_trees_t, ltree_id::t8_locidx_t, proc::Cint, eclass::t8_eclass_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_add_ghost(trees, lghost_index, gtree_id, proc, eclass, num_local_trees)
+
+Add a ghost to a trees structure.
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure to be updated.
+* `ghost_index`:\\[in\\] The index in the part array of the ghost to be inserted.
+* `tree_id`:\\[in\\] The global index of the ghost.
+* `proc`:\\[in\\] The mpirank of the process from which the ghost was received.
+* `eclass`:\\[in\\] The ghost's element class.
+* `num_local_trees`:\\[in\\] The number of local trees in the cmesh.
+### Prototype
+```c
+void t8_cmesh_trees_add_ghost (t8_cmesh_trees_t trees, t8_locidx_t lghost_index, t8_gloidx_t gtree_id, int proc, t8_eclass_t eclass, t8_locidx_t num_local_trees);
+```
+"""
+function t8_cmesh_trees_add_ghost(trees, lghost_index, gtree_id, proc, eclass, num_local_trees)
+    @ccall libt8.t8_cmesh_trees_add_ghost(trees::t8_cmesh_trees_t, lghost_index::t8_locidx_t, gtree_id::t8_gloidx_t, proc::Cint, eclass::t8_eclass_t, num_local_trees::t8_locidx_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_set_all_boundary(cmesh, trees)
+
+Set all neighbor fields of all local trees and ghosts to boundary.
+
+# Arguments
+* `cmesh,`:\\[in,out\\] The associated cmesh.
+* `trees,`:\\[in,out\\] The trees structure. A face f of tree t counts as boundary if the face-neighbor is also t at face f.
+### Prototype
+```c
+void t8_cmesh_trees_set_all_boundary (t8_cmesh_t cmesh, t8_cmesh_trees_t trees);
+```
+"""
+function t8_cmesh_trees_set_all_boundary(cmesh, trees)
+    @ccall libt8.t8_cmesh_trees_set_all_boundary(cmesh::t8_cmesh_t, trees::t8_cmesh_trees_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_get_part_data(trees, proc, first_tree, num_trees, first_ghost, num_ghosts)
+
+### Prototype
+```c
+void t8_cmesh_trees_get_part_data (t8_cmesh_trees_t trees, int proc, t8_locidx_t *first_tree, t8_locidx_t *num_trees, t8_locidx_t *first_ghost, t8_locidx_t *num_ghosts);
+```
+"""
+function t8_cmesh_trees_get_part_data(trees, proc, first_tree, num_trees, first_ghost, num_ghosts)
+    @ccall libt8.t8_cmesh_trees_get_part_data(trees::t8_cmesh_trees_t, proc::Cint, first_tree::Ptr{t8_locidx_t}, num_trees::Ptr{t8_locidx_t}, first_ghost::Ptr{t8_locidx_t}, num_ghosts::Ptr{t8_locidx_t})::Cvoid
+end
+
+"""
+    t8_cmesh_trees_get_tree(trees, ltree)
+
+Return a pointer to a specific tree in a trees struct.
+
+# Arguments
+* `trees`:\\[in\\] The tress structure where the tree is to be looked up.
+* `ltree`:\\[in\\] The local id of the tree.
+# Returns
+A pointer to the tree with local id *tree*.
+### Prototype
+```c
+t8_ctree_t t8_cmesh_trees_get_tree (t8_cmesh_trees_t trees, t8_locidx_t ltree);
+```
+"""
+function t8_cmesh_trees_get_tree(trees, ltree)
+    @ccall libt8.t8_cmesh_trees_get_tree(trees::t8_cmesh_trees_t, ltree::t8_locidx_t)::t8_ctree_t
+end
+
+"""
+    t8_cmesh_trees_get_tree_ext(trees, ltree_id, face_neigh, ttf)
+
+Return a pointer to a specific tree in a trees struct plus pointers to its face\\_neighbor and tree\\_to\\_face arrays.
+
+# Arguments
+* `trees`:\\[in\\] The trees structure where the tree is to be looked up.
+* `ltree_id`:\\[in\\] The local id of the tree.
+* `face_neigh`:\\[out\\] If not NULL a pointer to the trees face\\_neighbor array is stored here on return.
+* `ttf`:\\[out\\] If not NULL a pointer to the trees tree\\_to\\_face array is stored here on return.
+# Returns
+A pointer to the tree with local id *tree*.
+### Prototype
+```c
+t8_ctree_t t8_cmesh_trees_get_tree_ext (t8_cmesh_trees_t trees, t8_locidx_t ltree_id, t8_locidx_t **face_neigh, int8_t **ttf);
+```
+"""
+function t8_cmesh_trees_get_tree_ext(trees, ltree_id, face_neigh, ttf)
+    @ccall libt8.t8_cmesh_trees_get_tree_ext(trees::t8_cmesh_trees_t, ltree_id::t8_locidx_t, face_neigh::Ptr{Ptr{t8_locidx_t}}, ttf::Ptr{Ptr{Int8}})::t8_ctree_t
+end
+
+"""
+    t8_cmesh_trees_get_face_info(trees, ltreeid, face, ttf)
+
+Return the face neighbor of a tree at a given face and return the tree\\_to\\_face info
+
+# Arguments
+* `trees`:\\[in\\] The trees structure where the tree is to be looked up.
+* `ltreeid`:\\[in\\] The local id of the tree.
+* `face`:\\[in\\] A face of the tree.
+* `ttf`:\\[out\\] If not NULL the tree\\_to\\_face value of the face connection.
+# Returns
+The face neighbor that is stored for this face
+### Prototype
+```c
+t8_locidx_t t8_cmesh_trees_get_face_info (t8_cmesh_trees_t trees, t8_locidx_t ltreeid, int face, int8_t *ttf);
+```
+"""
+function t8_cmesh_trees_get_face_info(trees, ltreeid, face, ttf)
+    @ccall libt8.t8_cmesh_trees_get_face_info(trees::t8_cmesh_trees_t, ltreeid::t8_locidx_t, face::Cint, ttf::Ptr{Int8})::t8_locidx_t
+end
+
+"""
+    t8_cmesh_trees_get_face_neighbor(tree, face)
+
+Given a coarse tree and a face number, return the local id of the neighbor tree.
+
+# Arguments
+* `tree.`:\\[in\\] The coarse tree.
+* `face.`:\\[in\\] The face number.
+# Returns
+The local id of the neighbor tree.
+### Prototype
+```c
+t8_locidx_t t8_cmesh_trees_get_face_neighbor (const t8_ctree_t tree, const int face);
+```
+"""
+function t8_cmesh_trees_get_face_neighbor(tree, face)
+    @ccall libt8.t8_cmesh_trees_get_face_neighbor(tree::t8_ctree_t, face::Cint)::t8_locidx_t
+end
+
+"""
+    t8_cmesh_trees_get_face_neighbor_ext(tree, face, ttf)
+
+Given a coarse tree and a face number, return the local id of the neighbor tree together with its tree-to-face info.
+
+# Arguments
+* `tree`:\\[in\\] The coarse tree.
+* `face`:\\[in\\] The face number.
+* `ttf`:\\[out\\] If not NULL it is filled with the tree-to-face value for this face.
+# Returns
+The local id of the neighbor tree.
+### Prototype
+```c
+t8_locidx_t t8_cmesh_trees_get_face_neighbor_ext (const t8_ctree_t tree, const int face, int8_t *ttf);
+```
+"""
+function t8_cmesh_trees_get_face_neighbor_ext(tree, face, ttf)
+    @ccall libt8.t8_cmesh_trees_get_face_neighbor_ext(tree::t8_ctree_t, face::Cint, ttf::Ptr{Int8})::t8_locidx_t
+end
+
+"""
+    t8_cmesh_trees_get_ghost_face_neighbor_ext(ghost, face, ttf)
+
+Given a coarse ghost and a face number, return the local id of the neighbor tree together with its tree-to-face info.
+
+# Arguments
+* `ghost`:\\[in\\] The coarse ghost.
+* `face`:\\[in\\] The face number.
+* `ttf`:\\[out\\] If not NULL it is filled with the tree-to-face value for this face.
+# Returns
+The global id of the neighbor tree.
+### Prototype
+```c
+t8_gloidx_t t8_cmesh_trees_get_ghost_face_neighbor_ext (const t8_cghost_t ghost, const int face, int8_t *ttf);
+```
+"""
+function t8_cmesh_trees_get_ghost_face_neighbor_ext(ghost, face, ttf)
+    @ccall libt8.t8_cmesh_trees_get_ghost_face_neighbor_ext(ghost::t8_cghost_t, face::Cint, ttf::Ptr{Int8})::t8_gloidx_t
+end
+
+"""
+    t8_cmesh_trees_get_ghost(trees, lghost)
+
+Return a pointer to a specific ghost in a trees struct.
+
+# Arguments
+* `trees`:\\[in\\] The tress structure where the tree is to be looked up.
+* `lghost`:\\[in\\] The local id of the ghost.
+# Returns
+A pointer to the ghost with local id *ghost*.
+### Prototype
+```c
+t8_cghost_t t8_cmesh_trees_get_ghost (t8_cmesh_trees_t trees, t8_locidx_t lghost);
+```
+"""
+function t8_cmesh_trees_get_ghost(trees, lghost)
+    @ccall libt8.t8_cmesh_trees_get_ghost(trees::t8_cmesh_trees_t, lghost::t8_locidx_t)::t8_cghost_t
+end
+
+"""
+    t8_cmesh_trees_get_ghost_ext(trees, lghost_id, face_neigh, ttf)
+
+Return a pointer to a specific ghost in a trees struct plus pointers to its face\\_neighbor and tree\\_to\\_face arrays.
+
+# Arguments
+* `trees`:\\[in\\] The trees structure where the ghost is to be looked up.
+* `lghost_id`:\\[in\\] The local id of the ghost.
+* `face_neigh`:\\[out\\] If not NULL a pointer to the ghosts face\\_neighbor array is stored here on return.
+* `ttf`:\\[out\\] If not NULL a pointer to the ghosts tree\\_to\\_face array is stored here on return.
+# Returns
+A pointer to the tree with local id *tree*.
+### Prototype
+```c
+t8_cghost_t t8_cmesh_trees_get_ghost_ext (t8_cmesh_trees_t trees, t8_locidx_t lghost_id, t8_gloidx_t **face_neigh, int8_t **ttf);
+```
+"""
+function t8_cmesh_trees_get_ghost_ext(trees, lghost_id, face_neigh, ttf)
+    @ccall libt8.t8_cmesh_trees_get_ghost_ext(trees::t8_cmesh_trees_t, lghost_id::t8_locidx_t, face_neigh::Ptr{Ptr{t8_gloidx_t}}, ttf::Ptr{Ptr{Int8}})::t8_cghost_t
+end
+
+"""
+    t8_cmesh_trees_get_ghost_local_id(trees, global_id)
+
+Given the global tree id of a ghost tree in a trees structure, return its local ghost id.
+
+# Arguments
+* `trees`:\\[in\\] The trees structure.
+* `global_id`:\\[in\\] A global tree id.
+# Returns
+The local id of the tree *global_id* if it is a ghost in *trees*. A negative number if it isn't. The local id is a number l with num\\_local\\_trees <= *l* < num\\_local\\_trees + num\\_ghosts
+### Prototype
+```c
+t8_locidx_t t8_cmesh_trees_get_ghost_local_id (t8_cmesh_trees_t trees, t8_gloidx_t global_id);
+```
+"""
+function t8_cmesh_trees_get_ghost_local_id(trees, global_id)
+    @ccall libt8.t8_cmesh_trees_get_ghost_local_id(trees::t8_cmesh_trees_t, global_id::t8_gloidx_t)::t8_locidx_t
+end
+
+"""
+    t8_cmesh_trees_size(trees)
+
+### Prototype
+```c
+size_t t8_cmesh_trees_size (t8_cmesh_trees_t trees);
+```
+"""
+function t8_cmesh_trees_size(trees)
+    @ccall libt8.t8_cmesh_trees_size(trees::t8_cmesh_trees_t)::Csize_t
+end
+
+"""
+    t8_cmesh_trees_init_attributes(trees, ltree_id, num_attributes, attr_bytes)
+
+For one tree in a trees structure set the number of attributes and temporarily store the total size of all of this tree's attributes. This temporary value is used in t8_cmesh_trees_finish_part.
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure to be updated.
+* `ltree_id`:\\[in\\] The local id of one tree in *trees*.
+* `num_attributes`:\\[in\\] The number of attributes of this tree.
+* `attr_bytes`:\\[in\\] The total number of bytes of all attributes of this tree.
+### Prototype
+```c
+void t8_cmesh_trees_init_attributes (t8_cmesh_trees_t trees, t8_locidx_t ltree_id, size_t num_attributes, size_t attr_bytes);
+```
+"""
+function t8_cmesh_trees_init_attributes(trees, ltree_id, num_attributes, attr_bytes)
+    @ccall libt8.t8_cmesh_trees_init_attributes(trees::t8_cmesh_trees_t, ltree_id::t8_locidx_t, num_attributes::Csize_t, attr_bytes::Csize_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_get_attribute(trees, ltree_id, package_id, key, size, is_ghost)
+
+Return an attribute that is stored at a tree.
+
+# Arguments
+* `trees`:\\[in\\] The trees structure.
+* `ltree_id`:\\[in\\] The local id of the tree whose attribute is querid.
+* `package_id`:\\[in\\] The package identifier of the attribute.
+* `key`:\\[in\\] The key of the attribute within all attributes of the same package identifier.
+* `size`:\\[out\\] If not NULL, the size (in bytes) of the attribute will be stored here.
+* `is_ghost`:\\[in\\] If true, then *ltree_id* is interpreted as the local\\_id of a ghost.
+# Returns
+A pointer to the queried attribute, NULL if the attribute does not exist.
+### Prototype
+```c
+void * t8_cmesh_trees_get_attribute (const t8_cmesh_trees_t trees, const t8_locidx_t ltree_id, const int package_id, const int key, size_t *size, int is_ghost);
+```
+"""
+function t8_cmesh_trees_get_attribute(trees, ltree_id, package_id, key, size, is_ghost)
+    @ccall libt8.t8_cmesh_trees_get_attribute(trees::t8_cmesh_trees_t, ltree_id::t8_locidx_t, package_id::Cint, key::Cint, size::Ptr{Csize_t}, is_ghost::Cint)::Ptr{Cvoid}
+end
+
+"""
+    t8_cmesh_trees_attribute_size(tree)
+
+Return the total size of all attributes stored at a specified tree.
+
+# Arguments
+* `tree`:\\[in\\] A tree structure.
+# Returns
+The total size (in bytes) of the attributes of *tree*.
+### Prototype
+```c
+size_t t8_cmesh_trees_attribute_size (t8_ctree_t tree);
+```
+"""
+function t8_cmesh_trees_attribute_size(tree)
+    @ccall libt8.t8_cmesh_trees_attribute_size(tree::t8_ctree_t)::Csize_t
+end
+
+"""
+    t8_cmesh_trees_ghost_attribute_size(ghost)
+
+Return the total size of all attributes stored at a specified ghost.
+
+# Arguments
+* `ghost`:\\[in\\] A ghost structure.
+# Returns
+The total size (in bytes) of the attributes of *ghost*.
+### Prototype
+```c
+size_t t8_cmesh_trees_ghost_attribute_size (t8_cghost_t ghost);
+```
+"""
+function t8_cmesh_trees_ghost_attribute_size(ghost)
+    @ccall libt8.t8_cmesh_trees_ghost_attribute_size(ghost::t8_cghost_t)::Csize_t
+end
+
+"""
+    t8_cmesh_trees_add_attribute(trees, proc, attr, tree_id, index)
+
+### Prototype
+```c
+void t8_cmesh_trees_add_attribute (const t8_cmesh_trees_t trees, int proc, const t8_stash_attribute_struct_t *attr, t8_locidx_t tree_id, size_t index);
+```
+"""
+function t8_cmesh_trees_add_attribute(trees, proc, attr, tree_id, index)
+    @ccall libt8.t8_cmesh_trees_add_attribute(trees::t8_cmesh_trees_t, proc::Cint, attr::Ptr{t8_stash_attribute_struct_t}, tree_id::t8_locidx_t, index::Csize_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_add_ghost_attribute(trees, attr, local_ghost_id, ghosts_inserted, index)
+
+Add the next ghost attribute from stash to the correct position in the char pointer structure Since it is created from stash, all attributes are added to part 0. The following attribute offset gets updated already.
+
+# Arguments
+* `trees`:\\[in,out\\] The trees structure, whose char array is updated.
+* `attr`:\\[in\\] The stash attribute that is added.
+* `local_ghost_id`:\\[in\\] The local ghost id.
+* `ghosts_inserted`:\\[in\\] The number of ghost that were already inserted, so that we do not write over the end.
+* `index`:\\[in\\] The attribute index of the attribute to be added.
+### Prototype
+```c
+void t8_cmesh_trees_add_ghost_attribute (const t8_cmesh_trees_t trees, const t8_stash_attribute_struct_t *attr, t8_locidx_t local_ghost_id, t8_locidx_t ghosts_inserted, size_t index);
+```
+"""
+function t8_cmesh_trees_add_ghost_attribute(trees, attr, local_ghost_id, ghosts_inserted, index)
+    @ccall libt8.t8_cmesh_trees_add_ghost_attribute(trees::t8_cmesh_trees_t, attr::Ptr{t8_stash_attribute_struct_t}, local_ghost_id::t8_locidx_t, ghosts_inserted::t8_locidx_t, index::Csize_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_get_numproc(trees)
+
+Return the number of parts of a trees structure.
+
+# Arguments
+* `trees`:\\[in\\] The trees structure.
+# Returns
+The number of parts in *trees*.
+### Prototype
+```c
+size_t t8_cmesh_trees_get_numproc (const t8_cmesh_trees_t trees);
+```
+"""
+function t8_cmesh_trees_get_numproc(trees)
+    @ccall libt8.t8_cmesh_trees_get_numproc(trees::t8_cmesh_trees_t)::Csize_t
+end
+
+"""
+    t8_cmesh_tree_to_face_encode(dimension, face, orientation)
+
+Compute the tree-to-face information given a face and orientation value of a face connection.
+
+# Arguments
+* `dimension`:\\[in\\] The dimension of the corresponding eclasses.
+* `face`:\\[in\\] A face number
+* `orientation`:\\[in\\] A face-to-face orientation.
+# Returns
+The tree-to-face entry corresponding to the face/orientation combination. It is computed as t8\\_eclass\\_max\\_num\\_faces[dimension] * orientation + face
+### Prototype
+```c
+int8_t t8_cmesh_tree_to_face_encode (const int dimension, const t8_locidx_t face, const int orientation);
+```
+"""
+function t8_cmesh_tree_to_face_encode(dimension, face, orientation)
+    @ccall libt8.t8_cmesh_tree_to_face_encode(dimension::Cint, face::t8_locidx_t, orientation::Cint)::Int8
+end
+
+"""
+    t8_cmesh_tree_to_face_decode(dimension, tree_to_face, face, orientation)
+
+Given a tree-to-face value, get its encoded face number and orientation.
+
+!!! note
+
+    This function is the inverse operation of t8_cmesh_tree_to_face_encode If F = t8\\_eclass\\_max\\_num\\_faces[dimension], we get orientation = tree\\_to\\_face / F face = tree\\_to\\_face % F
+
+# Arguments
+* `dimension`:\\[in\\] The dimension of the corresponding eclasses.
+* `tree_to_face`:\\[in\\] A tree-to-face value
+* `face`:\\[out\\] On output filled with the stored face value.
+* `orientation`:\\[out\\] On output filled with the stored orientation value.
+### Prototype
+```c
+void t8_cmesh_tree_to_face_decode (const int dimension, const int8_t tree_to_face, int *face, int *orientation);
+```
+"""
+function t8_cmesh_tree_to_face_decode(dimension, tree_to_face, face, orientation)
+    @ccall libt8.t8_cmesh_tree_to_face_decode(dimension::Cint, tree_to_face::Int8, face::Ptr{Cint}, orientation::Ptr{Cint})::Cvoid
+end
+
+"""
+    t8_cmesh_trees_print(cmesh, trees)
+
+Print the trees,ghosts and their neighbors in ASCII format t stdout. This function is used for debugging purposes.
+
+# Arguments
+* `cmesh`:\\[in\\] A coarse mesh structure that must be committed.
+* `trees`:\\[in\\] The trees structure of *cmesh*.
+### Prototype
+```c
+void t8_cmesh_trees_print (t8_cmesh_t cmesh, t8_cmesh_trees_t trees);
+```
+"""
+function t8_cmesh_trees_print(cmesh, trees)
+    @ccall libt8.t8_cmesh_trees_print(cmesh::t8_cmesh_t, trees::t8_cmesh_trees_t)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_bcast(cmesh_in, root, comm)
+
+### Prototype
+```c
+void t8_cmesh_trees_bcast (t8_cmesh_t cmesh_in, int root, sc_MPI_Comm comm);
+```
+"""
+function t8_cmesh_trees_bcast(cmesh_in, root, comm)
+    @ccall libt8.t8_cmesh_trees_bcast(cmesh_in::t8_cmesh_t, root::Cint, comm::MPI_Comm)::Cvoid
+end
+
+"""
+    t8_cmesh_trees_is_face_consistent(cmesh, trees)
+
+Check whether the face connection of a trees structure are consistent. That is if tree1 lists tree2 as neighbor at face i with ttf entries (or,face j), then tree2 must list tree1 as neighbor at face j with ttf entries (or, face i).
+
+# Arguments
+* `cmesh`:\\[in\\] A cmesh structure to be checked.
+* `trees`:\\[in\\] The cmesh's trees struct.
+# Returns
+True if the face connections are consistent, False if not.
+### Prototype
+```c
+int t8_cmesh_trees_is_face_consistent (t8_cmesh_t cmesh, t8_cmesh_trees_t trees);
+```
+"""
+function t8_cmesh_trees_is_face_consistent(cmesh, trees)
+    @ccall libt8.t8_cmesh_trees_is_face_consistent(cmesh::t8_cmesh_t, trees::t8_cmesh_trees_t)::Cint
+end
+
+"""
+    t8_cmesh_trees_is_equal(cmesh, trees_a, trees_b)
+
+### Prototype
+```c
+int t8_cmesh_trees_is_equal (t8_cmesh_t cmesh, t8_cmesh_trees_t trees_a, t8_cmesh_trees_t trees_b);
+```
+"""
+function t8_cmesh_trees_is_equal(cmesh, trees_a, trees_b)
+    @ccall libt8.t8_cmesh_trees_is_equal(cmesh::t8_cmesh_t, trees_a::t8_cmesh_trees_t, trees_b::t8_cmesh_trees_t)::Cint
+end
+
+"""
+    t8_cmesh_trees_destroy(trees)
+
+Free all memory allocated with a trees structure. This means that all coarse trees and ghosts, their face neighbor entries and attributes and the additional structures of trees are freed.
+
+# Arguments
+* `trees`:\\[in,out\\] The tree structure to be destroyed. Set to NULL on output.
+### Prototype
+```c
+void t8_cmesh_trees_destroy (t8_cmesh_trees_t *trees);
+```
+"""
+function t8_cmesh_trees_destroy(trees)
+    @ccall libt8.t8_cmesh_trees_destroy(trees::Ptr{t8_cmesh_trees_t})::Cvoid
+end
+
+"""
+This structure holds the connectivity data of the coarse mesh. It can either be replicated, then each process stores a copy of the whole mesh, or partitioned. In the latter case, each process only stores a local portion of the mesh plus information about ghost elements.
+
+The coarse mesh is a collection of coarse trees that can be identified along faces. TODO: this description is outdated. rewrite it. The array ctrees stores these coarse trees sorted by their (global) tree\\_id. If the mesh if partitioned it is partitioned according to an (possible only virtually existing) underlying fine mesh. Therefore the ctrees array can store duplicated trees on different processes, if each of these processes owns elements of the same tree in the fine mesh.
+
+Each tree stores information about its face-neighbours in an array of t8_ctree_fneighbor.
+
+If partitioned the ghost trees are stored in a hash table that is backed up by an array. The hash value of a ghost tree is its tree\\_id modulo the number of ghosts on this process.
+
+# See also
+t8\\_ctree\\_fneighbor
+"""
+const t8_cmesh_struct_t = t8_cmesh
+
+const t8_cghost_struct_t = t8_cghost
+
+"""This structure holds the data of a local tree including the information about face neighbors. For those the tree\\_to\\_face index is computed as follows. Let F be the maximal number of faces of any eclass of the cmesh's dimension, then ttf % F is the face number and ttf / F is the orientation. (t8_eclass_max_num_faces) The orientation is determined as follows. Let my\\_face and other\\_face be the two face numbers of the connecting trees. We chose a main\\_face from them as follows: Either both trees have the same element class, then the face with the lower face number is the main\\_face or the trees belong to different classes in which case the face belonging to the tree with the lower class according to the ordering triangle < square, hex < tet < prism < pyramid, is the main\\_face. Then face corner 0 of the main\\_face connects to a face corner k in the other face. The face orientation is defined as the number k. If the classes are equal and my\\_face == other\\_face, treating either of both faces as the main\\_face leads to the same result. See https://arxiv.org/pdf/1611.02929.pdf for more details."""
+const t8_ctree_struct_t = t8_ctree
+
+const t8_cmesh_trees_struct_t = t8_cmesh_trees
+
+const t8_part_tree_struct_t = t8_part_tree
+
+"""
+This struct is used to profile cmesh algorithms. The cmesh struct stores a pointer to a profile struct, and if it is nonzero, various runtimes and data measurements are stored here.
+
+# See also
+[`t8_cmesh_set_profiling`](@ref) and, [`t8_cmesh_print_profile`](@ref)
+"""
+const t8_cprofile_struct_t = t8_cprofile
+
+"""
     t8_element_array_t
 
-The [`t8_element_array_t`](@ref) is an array to store [`t8_element_t`](@ref) * of a given eclass\\_scheme implementation. It is a wrapper around [`sc_array_t`](@ref). Each time, a new element is created by the functions for t8_element_array_t, the eclass function either t8_element_new or t8_element_init is called for the element. Thus, each element in a t8_element_array_t is automatically initialized properly.
+The [`t8_element_array_t`](@ref) is an array to store [`t8_element_t`](@ref) * of a given eclass\\_scheme implementation. It is a wrapper around sc_array_t. Each time, a new element is created by the functions for t8_element_array_t, the eclass function either t8_element_new or t8_element_init is called for the element. Thus, each element in a t8_element_array_t is automatically initialized properly.
 
-| Field        | Note                                                   |
-| :----------- | :----------------------------------------------------- |
-| scheme       | The scheme of which elements should be stored.         |
-| tree\\_class | !< A scheme of which elements should be stored         |
-| array        | !< The tree class of the elements stored in the array  |
+| Field  | Note                                                 |
+| :----- | :--------------------------------------------------- |
+| scheme | An eclass scheme of which elements should be stored  |
+| array  | The array in which the elements are stored           |
 """
 struct t8_element_array_t
-    scheme::Ptr{t8_scheme_c}
-    tree_class::t8_eclass_t
+    scheme::Ptr{t8_eclass_scheme_c}
     array::sc_array_t
 end
 
 """
-    t8_element_array_new(scheme, tree_class)
+    t8_element_array_new(scheme)
 
 Creates a new array structure with 0 elements.
 
 # Arguments
 * `scheme`:\\[in\\] The eclass scheme of which elements should be stored.
-* `tree_class`:\\[in\\] The tree class of the elements stored in the array.
 # Returns
 Return an allocated array of zero length.
 ### Prototype
 ```c
-t8_element_array_t * t8_element_array_new (const t8_scheme_c *scheme, const t8_eclass_t tree_class);
+t8_element_array_t * t8_element_array_new (t8_eclass_scheme_c *scheme);
 ```
 """
-function t8_element_array_new(scheme, tree_class)
-    @ccall libt8.t8_element_array_new(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Ptr{t8_element_array_t}
+function t8_element_array_new(scheme)
+    @ccall libt8.t8_element_array_new(scheme::Ptr{t8_eclass_scheme_c})::Ptr{t8_element_array_t}
 end
 
 """
-    t8_element_array_new_count(scheme, tree_class, num_elements)
+    t8_element_array_new_count(scheme, num_elements)
 
 Creates a new array structure with a given length (number of elements) and calls t8_element_new for those elements.
 
 # Arguments
 * `scheme`:\\[in\\] The eclass scheme of which elements should be stored.
-* `tree_class`:\\[in\\] The tree class of the elements stored in the array.
 * `num_elements`:\\[in\\] Initial number of array elements.
 # Returns
 Return an allocated array with allocated and initialized elements for which t8_element_new was called.
 ### Prototype
 ```c
-t8_element_array_t * t8_element_array_new_count (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const size_t num_elements);
+t8_element_array_t * t8_element_array_new_count (t8_eclass_scheme_c *scheme, size_t num_elements);
 ```
 """
-function t8_element_array_new_count(scheme, tree_class, num_elements)
-    @ccall libt8.t8_element_array_new_count(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, num_elements::Csize_t)::Ptr{t8_element_array_t}
+function t8_element_array_new_count(scheme, num_elements)
+    @ccall libt8.t8_element_array_new_count(scheme::Ptr{t8_eclass_scheme_c}, num_elements::Csize_t)::Ptr{t8_element_array_t}
 end
 
 """
-    t8_element_array_init(element_array, scheme, tree_class)
+    t8_element_array_init(element_array, scheme)
 
 Initializes an already allocated (or static) array structure.
 
 # Arguments
 * `element_array`:\\[in,out\\] Array structure to be initialized.
 * `scheme`:\\[in\\] The eclass scheme of which elements should be stored.
-* `tree_class`:\\[in\\] The tree class of the elements stored in the array.
 ### Prototype
 ```c
-void t8_element_array_init (t8_element_array_t *element_array, const t8_scheme_c *scheme, const t8_eclass_t tree_class);
+void t8_element_array_init (t8_element_array_t *element_array, t8_eclass_scheme_c *scheme);
 ```
 """
-function t8_element_array_init(element_array, scheme, tree_class)
-    @ccall libt8.t8_element_array_init(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Cvoid
+function t8_element_array_init(element_array, scheme)
+    @ccall libt8.t8_element_array_init(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_eclass_scheme_c})::Cvoid
 end
 
 """
-    t8_element_array_init_size(element_array, scheme, tree_class, num_elements)
+    t8_element_array_init_size(element_array, scheme, num_elements)
 
 Initializes an already allocated (or static) array structure and allocates a given number of elements and initializes them with t8_element_init.
 
 # Arguments
 * `element_array`:\\[in,out\\] Array structure to be initialized.
 * `scheme`:\\[in\\] The eclass scheme of which elements should be stored.
-* `tree_class`:\\[in\\] The tree class of the elements stored in the array.
 * `num_elements`:\\[in\\] Number of initial array elements.
 ### Prototype
 ```c
-void t8_element_array_init_size (t8_element_array_t *element_array, const t8_scheme_c *scheme, const t8_eclass_t tree_class, const size_t num_elements);
+void t8_element_array_init_size (t8_element_array_t *element_array, t8_eclass_scheme_c *scheme, size_t num_elements);
 ```
 """
-function t8_element_array_init_size(element_array, scheme, tree_class, num_elements)
-    @ccall libt8.t8_element_array_init_size(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, num_elements::Csize_t)::Cvoid
+function t8_element_array_init_size(element_array, scheme, num_elements)
+    @ccall libt8.t8_element_array_init_size(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_eclass_scheme_c}, num_elements::Csize_t)::Cvoid
 end
 
 """
@@ -8750,56 +13972,49 @@ Initializes an already allocated (or static) view from existing t8\\_element\\_a
 * `length`:\\[in\\] The length of the view in element units. The view cannot be resized to exceed this length. It is not necessary to call [`sc_array_reset`](@ref) later.
 ### Prototype
 ```c
-void t8_element_array_init_view (t8_element_array_t *view, const t8_element_array_t *array, const size_t offset, const size_t length);
+void t8_element_array_init_view (t8_element_array_t *view, t8_element_array_t *array, size_t offset, size_t length);
 ```
 """
 function t8_element_array_init_view(view, array, offset, length)
     @ccall libt8.t8_element_array_init_view(view::Ptr{t8_element_array_t}, array::Ptr{t8_element_array_t}, offset::Csize_t, length::Csize_t)::Cvoid
 end
 
-mutable struct t8_element end
-
-"""Opaque structure for a generic element, only used as pointer. Implementations are free to cast it to their internal data structure."""
-const t8_element_t = t8_element
-
 """
-    t8_element_array_init_data(view, base, scheme, tree_class, elem_count)
+    t8_element_array_init_data(view, base, scheme, elem_count)
 
 Initializes an already allocated (or static) view from given plain C data (array of [`t8_element_t`](@ref)). The array view returned does not require [`t8_element_array_reset`](@ref) (doesn't hurt though).
 
 # Arguments
 * `view`:\\[in,out\\] Array structure to be initialized.
 * `base`:\\[in\\] The data must not be moved while view is alive. Must be an array of [`t8_element_t`](@ref) corresponding to *scheme*.
-* `scheme`:\\[in\\] The scheme of the elements stored in *base*.
-* `tree_class`:\\[in\\] The tree class of the elements stored in *base*.
+* `scheme`:\\[in\\] The eclass scheme of the elements stored in *base*.
 * `elem_count`:\\[in\\] The length of the view in element units. The view cannot be resized to exceed this length. It is not necessary to call [`t8_element_array_reset`](@ref) later.
 ### Prototype
 ```c
-void t8_element_array_init_data (t8_element_array_t *view, const t8_element_t *base, const t8_scheme_c *scheme, const t8_eclass_t tree_class, const size_t elem_count);
+void t8_element_array_init_data (t8_element_array_t *view, t8_element_t *base, t8_eclass_scheme_c *scheme, size_t elem_count);
 ```
 """
-function t8_element_array_init_data(view, base, scheme, tree_class, elem_count)
-    @ccall libt8.t8_element_array_init_data(view::Ptr{t8_element_array_t}, base::Ptr{t8_element_t}, scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem_count::Csize_t)::Cvoid
+function t8_element_array_init_data(view, base, scheme, elem_count)
+    @ccall libt8.t8_element_array_init_data(view::Ptr{t8_element_array_t}, base::Ptr{t8_element_t}, scheme::Ptr{t8_eclass_scheme_c}, elem_count::Csize_t)::Cvoid
 end
 
 """
-    t8_element_array_init_copy(element_array, scheme, tree_class, data, num_elements)
+    t8_element_array_init_copy(element_array, scheme, data, num_elements)
 
 Initializes an already allocated (or static) array structure and copy an existing array of [`t8_element_t`](@ref) into it.
 
 # Arguments
 * `element_array`:\\[in,out\\] Array structure to be initialized.
 * `scheme`:\\[in\\] The eclass scheme of which elements should be stored.
-* `tree_class`:\\[in\\] The tree class of the elements stored in the array.
 * `data`:\\[in\\] An array of [`t8_element_t`](@ref) which will be copied into *element_array*. The elements in *data* must belong to *scheme* and must be properly initialized with either t8_element_new or t8_element_init.
 * `num_elements`:\\[in\\] Number of elements in *data* to be copied.
 ### Prototype
 ```c
-void t8_element_array_init_copy (t8_element_array_t *element_array, const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *data, const size_t num_elements);
+void t8_element_array_init_copy (t8_element_array_t *element_array, t8_eclass_scheme_c *scheme, t8_element_t *data, size_t num_elements);
 ```
 """
-function t8_element_array_init_copy(element_array, scheme, tree_class, data, num_elements)
-    @ccall libt8.t8_element_array_init_copy(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, data::Ptr{t8_element_t}, num_elements::Csize_t)::Cvoid
+function t8_element_array_init_copy(element_array, scheme, data, num_elements)
+    @ccall libt8.t8_element_array_init_copy(element_array::Ptr{t8_element_array_t}, scheme::Ptr{t8_eclass_scheme_c}, data::Ptr{t8_element_t}, num_elements::Csize_t)::Cvoid
 end
 
 """
@@ -8816,7 +14031,7 @@ Change the number of elements stored in an element array.
 * `new_count`:\\[in\\] The new element count of the array. If it is zero the effect equals t8_element_array_reset.
 ### Prototype
 ```c
-void t8_element_array_resize (t8_element_array_t *element_array, const size_t new_count);
+void t8_element_array_resize (t8_element_array_t *element_array, size_t new_count);
 ```
 """
 function t8_element_array_resize(element_array, new_count)
@@ -8846,7 +14061,7 @@ end
 Enlarge an array by one element.
 
 # Arguments
-* `element_array`:\\[in,out\\] Array structure to be modified.
+* `element_array`:\\[in\\] Array structure to be modified.
 # Returns
 Returns a pointer to a newly added element for which t8_element_init was called.
 ### Prototype
@@ -8864,7 +14079,7 @@ end
 Enlarge an array by a number of elements.
 
 # Arguments
-* `element_array`:\\[in,out\\] Array structure to be modified.
+* `element_array`:\\[in\\] Array structure to be modified.
 * `count`:\\[in\\] The number of elements to add.
 # Returns
 Returns a pointer to the newly added elements for which t8_element_init was called.
@@ -8889,7 +14104,7 @@ Return a given element in an array. Const version.
 A pointer to the element stored at position *index* in *element_array*.
 ### Prototype
 ```c
-const t8_element_t * t8_element_array_index_locidx (const t8_element_array_t *element_array, const t8_locidx_t index);
+const t8_element_t * t8_element_array_index_locidx (const t8_element_array_t *element_array, t8_locidx_t index);
 ```
 """
 function t8_element_array_index_locidx(element_array, index)
@@ -8908,7 +14123,7 @@ Return a given element in an array. Const version.
 A pointer to the element stored at position *index* in *element_array*.
 ### Prototype
 ```c
-const t8_element_t * t8_element_array_index_int (const t8_element_array_t *element_array, const int index);
+const t8_element_t * t8_element_array_index_int (const t8_element_array_t *element_array, int index);
 ```
 """
 function t8_element_array_index_int(element_array, index)
@@ -8927,7 +14142,7 @@ Return a given element in an array. Mutable version.
 A pointer to the element stored at position *index* in *element_array*.
 ### Prototype
 ```c
-t8_element_t * t8_element_array_index_locidx_mutable (t8_element_array_t *element_array, const t8_locidx_t index);
+t8_element_t * t8_element_array_index_locidx_mutable (t8_element_array_t *element_array, t8_locidx_t index);
 ```
 """
 function t8_element_array_index_locidx_mutable(element_array, index)
@@ -8946,7 +14161,7 @@ Return a given element in an array. Mutable version.
 A pointer to the element stored at position *index* in *element_array*.
 ### Prototype
 ```c
-t8_element_t * t8_element_array_index_int_mutable (t8_element_array_t *element_array, const int index);
+t8_element_t * t8_element_array_index_int_mutable (t8_element_array_t *element_array, int index);
 ```
 """
 function t8_element_array_index_int_mutable(element_array, index)
@@ -8964,29 +14179,11 @@ Return the eclass scheme associated to a t8\\_element\\_array.
 The eclass scheme stored at *element_array*.
 ### Prototype
 ```c
-const t8_scheme_c * t8_element_array_get_scheme (const t8_element_array_t *element_array);
+const t8_eclass_scheme_c * t8_element_array_get_scheme (const t8_element_array_t *element_array);
 ```
 """
 function t8_element_array_get_scheme(element_array)
-    @ccall libt8.t8_element_array_get_scheme(element_array::Ptr{t8_element_array_t})::Ptr{t8_scheme_c}
-end
-
-"""
-    t8_element_array_get_tree_class(element_array)
-
-Return the tree class of the t8\\_element\\_array .
-
-# Arguments
-* `element_array`:\\[in\\] Array of elements.
-# Returns
-The tree class stored at *element_array*.
-### Prototype
-```c
-t8_eclass_t t8_element_array_get_tree_class (const t8_element_array_t *element_array);
-```
-"""
-function t8_element_array_get_tree_class(element_array)
-    @ccall libt8.t8_element_array_get_tree_class(element_array::Ptr{t8_element_array_t})::t8_eclass_t
+    @ccall libt8.t8_element_array_get_scheme(element_array::Ptr{t8_element_array_t})::Ptr{t8_eclass_scheme_c}
 end
 
 """
@@ -9106,25 +14303,6 @@ function t8_element_array_get_array_mutable(element_array)
 end
 
 """
-    t8_element_array_find(element_array, element)
-
-Search for an element in an array.
-
-# Arguments
-* `element_array`:\\[in\\] Array structure.
-* `element`:\\[in\\] Element to be found in *element_array*.  The element must have been created with the scheme used in *element_array*.
-# Returns
-If *element* was found in *element_array* then the position in the array is returned. If the element is not found, -1 is returned.
-### Prototype
-```c
-t8_locidx_t t8_element_array_find (const t8_element_array_t *element_array, const t8_element_t *element);
-```
-"""
-function t8_element_array_find(element_array, element)
-    @ccall libt8.t8_element_array_find(element_array::Ptr{t8_element_array_t}, element::Ptr{t8_element_t})::t8_locidx_t
-end
-
-"""
     t8_element_array_reset(element_array)
 
 Sets the array count to zero and frees all elements.
@@ -9169,11 +14347,11 @@ end
 
 ### Prototype
 ```c
-int t8_shmem_init (sc_MPI_Comm comm);
+void t8_shmem_init (sc_MPI_Comm comm);
 ```
 """
 function t8_shmem_init(comm)
-    @ccall libt8.t8_shmem_init(comm::MPI_Comm)::Cint
+    @ccall libt8.t8_shmem_init(comm::MPI_Comm)::Cvoid
 end
 
 """
@@ -9215,7 +14393,7 @@ end
 """
     t8_shmem_array_start_writing(array)
 
-Enable writing mode for a shmem array. Only some processes may be allowed to write into the array, which is indicated by the return value being non-zero. The shared memory is managed via inter- and intranode communicators. Only rank 0 of the intranode communicator will be allowed to write into the array.
+Enable writing mode for a shmem array. Only some processes may be allowed to write into the array, which is indicated by the return value being non-zero.
 
 !!! note
 
@@ -9526,17 +14704,6 @@ end
 """
     t8_shmem_array_is_equal(array_a, array_b)
 
-Check if two t8\\_shmem arrays are equal.
-
-!!! note
-
-    Writing mode must be disabled for *array_a* and *array_b*.
-
-# Arguments
-* `array_a`:\\[in\\] The first [`t8_shmem_array`](@ref) to compare.
-* `array_b`:\\[in\\] The second [`t8_shmem_array`](@ref) to compare.
-# Returns
-1 if the arrays are equal, 0 otherwise.
 ### Prototype
 ```c
 int t8_shmem_array_is_equal (t8_shmem_array_t array_a, t8_shmem_array_t array_b);
@@ -9563,952 +14730,8 @@ function t8_shmem_array_destroy(parray)
 end
 
 """
-    t8_shmem_array_binary_search(array, value, size, compare)
-
-Perform a binary search in a [`t8_shmem_array`](@ref).
-
-# Arguments
-* `array`:\\[in\\] The [`t8_shmem_array`](@ref) to search in.
-* `value`:\\[in\\] The value to search for.
-* `size`:\\[in\\] The number of elements in the array.
-* `compare`:\\[in\\] A function that compares an element of the array with the value.
-# Returns
-The index of the element in *array* that matches *value*.
-### Prototype
-```c
-int t8_shmem_array_binary_search (t8_shmem_array_t array, const t8_gloidx_t value, const int size, int (*compare) (t8_shmem_array_t, const int, const t8_gloidx_t));
-```
-"""
-function t8_shmem_array_binary_search(array, value, size, compare)
-    @ccall libt8.t8_shmem_array_binary_search(array::t8_shmem_array_t, value::t8_gloidx_t, size::Cint, compare::Ptr{Cvoid})::Cint
-end
-
-"""
-    t8_eclass_count_boundary(theclass, min_dim, per_eclass)
-
-Query the element class and count of boundary points.
-
-# Arguments
-* `theclass`:\\[in\\] We query a point of this element class.
-* `min_dim`:\\[in\\] Ignore boundary points of lesser dimension. The ignored points get a count value of 0.
-* `per_eclass`:\\[out\\] Array of length T8\\_ECLASS\\_COUNT to be filled with the count of the boundary objects, counted per each of the element classes.
-# Returns
-The count over all boundary points.
-### Prototype
-```c
-int t8_eclass_count_boundary (t8_eclass_t theclass, int min_dim, int *per_eclass);
-```
-"""
-function t8_eclass_count_boundary(theclass, min_dim, per_eclass)
-    @ccall libt8.t8_eclass_count_boundary(theclass::t8_eclass_t, min_dim::Cint, per_eclass::Ptr{Cint})::Cint
-end
-
-"""
-    t8_eclass_compare(eclass1, eclass2)
-
-Compare two eclasses of the same dimension as necessary for face neighbor orientation. The implemented order is Triangle < Square in 2D and Tet < Hex < Prism < Pyramid in 3D.
-
-# Arguments
-* `eclass1`:\\[in\\] The first eclass to compare.
-* `eclass2`:\\[in\\] The second eclass to compare.
-# Returns
-0 if the eclasses are equal, 1 if eclass1 > eclass2 and -1 if eclass1 < eclass2
-### Prototype
-```c
-int t8_eclass_compare (t8_eclass_t eclass1, t8_eclass_t eclass2);
-```
-"""
-function t8_eclass_compare(eclass1, eclass2)
-    @ccall libt8.t8_eclass_compare(eclass1::t8_eclass_t, eclass2::t8_eclass_t)::Cint
-end
-
-"""
-    t8_eclass_is_valid(eclass)
-
-Check whether a class is a valid class. Returns non-zero if it is a valid class, returns zero, if the class is equal to T8\\_ECLASS\\_INVALID.
-
-# Arguments
-* `eclass`:\\[in\\] The eclass to check.
-# Returns
-Non-zero if *eclass* is valid, zero otherwise.
-### Prototype
-```c
-int t8_eclass_is_valid (t8_eclass_t eclass);
-```
-"""
-function t8_eclass_is_valid(eclass)
-    @ccall libt8.t8_eclass_is_valid(eclass::t8_eclass_t)::Cint
-end
-
-"""Type definition for the geometric shape of an element. Currently the possible shapes are the same as the possible element classes. I.e. T8\\_ECLASS\\_VERTEX, T8\\_ECLASS\\_TET, etc..."""
-const t8_element_shape_t = t8_eclass_t
-
-"""
-    t8_element_shape_num_faces(element_shape)
-
-The number of codimension-one boundaries of an element class.
-
-### Prototype
-```c
-int t8_element_shape_num_faces (int element_shape);
-```
-"""
-function t8_element_shape_num_faces(element_shape)
-    @ccall libt8.t8_element_shape_num_faces(element_shape::Cint)::Cint
-end
-
-"""
-    t8_element_shape_max_num_faces(element_shape)
-
-For each dimension the maximum possible number of faces of an element\\_shape of that dimension.
-
-### Prototype
-```c
-int t8_element_shape_max_num_faces (int element_shape);
-```
-"""
-function t8_element_shape_max_num_faces(element_shape)
-    @ccall libt8.t8_element_shape_max_num_faces(element_shape::Cint)::Cint
-end
-
-"""
-    t8_element_shape_num_vertices(element_shape)
-
-The number of vertices of an element class.
-
-### Prototype
-```c
-int t8_element_shape_num_vertices (int element_shape);
-```
-"""
-function t8_element_shape_num_vertices(element_shape)
-    @ccall libt8.t8_element_shape_num_vertices(element_shape::Cint)::Cint
-end
-
-"""
-    t8_element_shape_vtk_type(element_shape)
-
-The vtk cell type for the element\\_shape
-
-### Prototype
-```c
-int t8_element_shape_vtk_type (int element_shape);
-```
-"""
-function t8_element_shape_vtk_type(element_shape)
-    @ccall libt8.t8_element_shape_vtk_type(element_shape::Cint)::Cint
-end
-
-"""
-    t8_element_shape_t8_to_vtk_corner_number(element_shape, index)
-
-Maps the t8code corner number of the element to the vtk corner number
-
-# Arguments
-* `element_shape`:\\[in\\] The shape of the element.
-* `index`:\\[in\\] The index of the corner in z-order (t8code numeration).
-# Returns
-The corresponding vtk index.
-### Prototype
-```c
-int t8_element_shape_t8_to_vtk_corner_number (int element_shape, int index);
-```
-"""
-function t8_element_shape_t8_to_vtk_corner_number(element_shape, index)
-    @ccall libt8.t8_element_shape_t8_to_vtk_corner_number(element_shape::Cint, index::Cint)::Cint
-end
-
-"""
-    t8_element_shape_t8_corner_number(element_shape, index)
-
-Maps the vtk corner number of the element to the t8code corner number
-
-# Arguments
-* `element_shape`:\\[in\\] The shape of the element.
-* `index`:\\[in\\] The index of the corner in vtk ordering.
-# Returns
-The corresponding t8code index.
-### Prototype
-```c
-int t8_element_shape_t8_corner_number (int element_shape, int index);
-```
-"""
-function t8_element_shape_t8_corner_number(element_shape, index)
-    @ccall libt8.t8_element_shape_t8_corner_number(element_shape::Cint, index::Cint)::Cint
-end
-
-"""
-    t8_element_shape_to_string(element_shape)
-
-For each element\\_shape, the name of this class as a string
-
-### Prototype
-```c
-const char* t8_element_shape_to_string (int element_shape);
-```
-"""
-function t8_element_shape_to_string(element_shape)
-    @ccall libt8.t8_element_shape_to_string(element_shape::Cint)::Cstring
-end
-
-"""
-    t8_element_shape_compare(element_shape1, element_shape2)
-
-Compare two element\\_shapes of the same dimension as necessary for face neighbor orientation. The implemented order is Triangle < Square in 2D and Tet < Hex < Prism < Pyramid in 3D.
-
-# Arguments
-* `element_shape1`:\\[in\\] The first element\\_shape to compare.
-* `element_shape2`:\\[in\\] The second element\\_shape to compare.
-# Returns
-0 if the element\\_shapes are equal, 1 if element\\_shape1 > element\\_shape2 and -1 if element\\_shape1 < element\\_shape2
-### Prototype
-```c
-int t8_element_shape_compare (t8_element_shape_t element_shape1, t8_element_shape_t element_shape2);
-```
-"""
-function t8_element_shape_compare(element_shape1, element_shape2)
-    @ccall libt8.t8_element_shape_compare(element_shape1::t8_element_shape_t, element_shape2::t8_element_shape_t)::Cint
-end
-
-"""
-    sc_keyvalue_entry_type_t
-
-The values can have different types.
-
-| Enumerator                      | Note                                        |
-| :------------------------------ | :------------------------------------------ |
-| SC\\_KEYVALUE\\_ENTRY\\_NONE    | Designate an invalid situation.             |
-| SC\\_KEYVALUE\\_ENTRY\\_INT     | Used for values of type int.                |
-| SC\\_KEYVALUE\\_ENTRY\\_DOUBLE  | Used for values of type double.             |
-| SC\\_KEYVALUE\\_ENTRY\\_STRING  | Used for values of type const char *.       |
-| SC\\_KEYVALUE\\_ENTRY\\_POINTER | Used for values of anonymous pointer type.  |
-"""
-@cenum sc_keyvalue_entry_type_t::UInt32 begin
-    SC_KEYVALUE_ENTRY_NONE = 0
-    SC_KEYVALUE_ENTRY_INT = 1
-    SC_KEYVALUE_ENTRY_DOUBLE = 2
-    SC_KEYVALUE_ENTRY_STRING = 3
-    SC_KEYVALUE_ENTRY_POINTER = 4
-end
-
-mutable struct sc_keyvalue end
-
-"""The key-value container is an opaque structure."""
-const sc_keyvalue_t = sc_keyvalue
-
-# no prototype is found for this function at sc_keyvalue.h:54:21, please use with caution
-"""
-    sc_keyvalue_new()
-
-Create a new key-value container.
-
-# Returns
-The container is ready to use.
-### Prototype
-```c
-sc_keyvalue_t *sc_keyvalue_new ();
-```
-"""
-function sc_keyvalue_new()
-    @ccall libsc.sc_keyvalue_new()::Ptr{sc_keyvalue_t}
-end
-
-# automatic type deduction for variadic arguments may not be what you want, please use with caution
-@generated function sc_keyvalue_newf(dummy, va_list...)
-        :(@ccall(libsc.sc_keyvalue_newf(dummy::Cint; $(to_c_type_pairs(va_list)...))::Ptr{sc_keyvalue_t}))
-    end
-
-"""
-    sc_keyvalue_destroy(kv)
-
-Free a key-value container and all internal memory for key storage.
-
-# Arguments
-* `kv`:\\[in,out\\] The key-value container is invalidated by this call.
-### Prototype
-```c
-void sc_keyvalue_destroy (sc_keyvalue_t * kv);
-```
-"""
-function sc_keyvalue_destroy(kv)
-    @ccall libsc.sc_keyvalue_destroy(kv::Ptr{sc_keyvalue_t})::Cvoid
-end
-
-"""
-    sc_keyvalue_exists(kv, key)
-
-Routine to check existence of an entry.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key to query.
-# Returns
-The entry's type if found and SC\\_KEYVALUE\\_ENTRY\\_NONE otherwise.
-### Prototype
-```c
-sc_keyvalue_entry_type_t sc_keyvalue_exists (sc_keyvalue_t * kv, const char *key);
-```
-"""
-function sc_keyvalue_exists(kv, key)
-    @ccall libsc.sc_keyvalue_exists(kv::Ptr{sc_keyvalue_t}, key::Cstring)::sc_keyvalue_entry_type_t
-end
-
-"""
-    sc_keyvalue_unset(kv, key)
-
-Routine to remove an entry.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key to remove if it exists.
-# Returns
-The entry's type if found and removed, SC\\_KEYVALUE\\_ENTRY\\_NONE otherwise.
-### Prototype
-```c
-sc_keyvalue_entry_type_t sc_keyvalue_unset (sc_keyvalue_t * kv, const char *key);
-```
-"""
-function sc_keyvalue_unset(kv, key)
-    @ccall libsc.sc_keyvalue_unset(kv::Ptr{sc_keyvalue_t}, key::Cstring)::sc_keyvalue_entry_type_t
-end
-
-"""
-    sc_keyvalue_get_int(kv, key, dvalue)
-
-Routines to retrieve an integer value by its key. This function asserts that the key, if existing, points to the correct type.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key, may or may not exist.
-* `dvalue`:\\[in\\] Default value returned if key is not found.
-# Returns
-If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
-### Prototype
-```c
-int sc_keyvalue_get_int (sc_keyvalue_t * kv, const char *key, int dvalue);
-```
-"""
-function sc_keyvalue_get_int(kv, key, dvalue)
-    @ccall libsc.sc_keyvalue_get_int(kv::Ptr{sc_keyvalue_t}, key::Cstring, dvalue::Cint)::Cint
-end
-
-"""
-    sc_keyvalue_get_double(kv, key, dvalue)
-
-Retrieve a double value by its key. This function asserts that the key, if existing, points to the correct type.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key, may or may not exist.
-* `dvalue`:\\[in\\] Default value returned if key is not found.
-# Returns
-If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
-### Prototype
-```c
-double sc_keyvalue_get_double (sc_keyvalue_t * kv, const char *key, double dvalue);
-```
-"""
-function sc_keyvalue_get_double(kv, key, dvalue)
-    @ccall libsc.sc_keyvalue_get_double(kv::Ptr{sc_keyvalue_t}, key::Cstring, dvalue::Cdouble)::Cdouble
-end
-
-"""
-    sc_keyvalue_get_string(kv, key, dvalue)
-
-Retrieve a string value by its key. This function asserts that the key, if existing, points to the correct type.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key, may or may not exist.
-* `dvalue`:\\[in\\] Default value returned if key is not found.
-# Returns
-If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
-### Prototype
-```c
-const char *sc_keyvalue_get_string (sc_keyvalue_t * kv, const char *key, const char *dvalue);
-```
-"""
-function sc_keyvalue_get_string(kv, key, dvalue)
-    @ccall libsc.sc_keyvalue_get_string(kv::Ptr{sc_keyvalue_t}, key::Cstring, dvalue::Cstring)::Cstring
-end
-
-"""
-    sc_keyvalue_get_pointer(kv, key, dvalue)
-
-Retrieve a pointer value by its key. This function asserts that the key, if existing, points to the correct type.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `key`:\\[in\\] Lookup key, may or may not exist.
-* `dvalue`:\\[in\\] Default value returned if key is not found.
-# Returns
-If key is not present then **dvalue** is returned, otherwise the value stored under **key**.
-### Prototype
-```c
-void *sc_keyvalue_get_pointer (sc_keyvalue_t * kv, const char *key, void *dvalue);
-```
-"""
-function sc_keyvalue_get_pointer(kv, key, dvalue)
-    @ccall libsc.sc_keyvalue_get_pointer(kv::Ptr{sc_keyvalue_t}, key::Cstring, dvalue::Ptr{Cvoid})::Ptr{Cvoid}
-end
-
-"""
-    sc_keyvalue_get_int_check(kv, key, status)
-
-Query an integer key with error checking. We check whether the key is not found or it is of the wrong type. A default value to be returned on error can be passed in as *status. If status is NULL, then the result on error is undefined.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value table.
-* `key`:\\[in\\] Non-NULL key string.
-* `status`:\\[in,out\\] If not NULL, set to 0 if there is no error, 1 if the key is not found, 2 if a value is found but its type is not integer, and return the input value *status on error.
-# Returns
-On error we return *status if status is not NULL, and else an undefined value backed by an assertion. Without error, return the result of the lookup.
-### Prototype
-```c
-int sc_keyvalue_get_int_check (sc_keyvalue_t * kv, const char *key, int *status);
-```
-"""
-function sc_keyvalue_get_int_check(kv, key, status)
-    @ccall libsc.sc_keyvalue_get_int_check(kv::Ptr{sc_keyvalue_t}, key::Cstring, status::Ptr{Cint})::Cint
-end
-
-"""
-    sc_keyvalue_set_int(kv, key, newvalue)
-
-Routine to set an integer value for a given key.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value table.
-* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type integer.
-* `newvalue`:\\[in\\] New value will be stored under key.
-### Prototype
-```c
-void sc_keyvalue_set_int (sc_keyvalue_t * kv, const char *key, int newvalue);
-```
-"""
-function sc_keyvalue_set_int(kv, key, newvalue)
-    @ccall libsc.sc_keyvalue_set_int(kv::Ptr{sc_keyvalue_t}, key::Cstring, newvalue::Cint)::Cvoid
-end
-
-"""
-    sc_keyvalue_set_double(kv, key, newvalue)
-
-Routine to set a double value for a given key.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value table.
-* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type double.
-* `newvalue`:\\[in\\] New value will be stored under key.
-### Prototype
-```c
-void sc_keyvalue_set_double (sc_keyvalue_t * kv, const char *key, double newvalue);
-```
-"""
-function sc_keyvalue_set_double(kv, key, newvalue)
-    @ccall libsc.sc_keyvalue_set_double(kv::Ptr{sc_keyvalue_t}, key::Cstring, newvalue::Cdouble)::Cvoid
-end
-
-"""
-    sc_keyvalue_set_string(kv, key, newvalue)
-
-Routine to set a string value for a given key.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value table.
-* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type string.
-* `newvalue`:\\[in\\] New value will be stored under key.
-### Prototype
-```c
-void sc_keyvalue_set_string (sc_keyvalue_t * kv, const char *key, const char *newvalue);
-```
-"""
-function sc_keyvalue_set_string(kv, key, newvalue)
-    @ccall libsc.sc_keyvalue_set_string(kv::Ptr{sc_keyvalue_t}, key::Cstring, newvalue::Cstring)::Cvoid
-end
-
-"""
-    sc_keyvalue_set_pointer(kv, key, newvalue)
-
-Routine to set a pointer value for a given key.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value table.
-* `key`:\\[in\\] Non-NULL key to insert or replace. If it already exists, it must be of type pointer.
-* `newvalue`:\\[in\\] New value will be stored under key.
-### Prototype
-```c
-void sc_keyvalue_set_pointer (sc_keyvalue_t * kv, const char *key, void *newvalue);
-```
-"""
-function sc_keyvalue_set_pointer(kv, key, newvalue)
-    @ccall libsc.sc_keyvalue_set_pointer(kv::Ptr{sc_keyvalue_t}, key::Cstring, newvalue::Ptr{Cvoid})::Cvoid
-end
-
-# typedef int ( * sc_keyvalue_foreach_t ) ( const char * key , const sc_keyvalue_entry_type_t type , void * entry , const void * u )
-"""
-Function to call on every key value pair
-
-# Arguments
-* `key`:\\[in\\] The key for this pair
-* `type`:\\[in\\] The type of entry
-* `entry`:\\[in\\] Pointer to the entry
-* `u`:\\[in\\] Arbitrary user data.
-# Returns
-Return true if the traversal should continue, false to stop.
-"""
-const sc_keyvalue_foreach_t = Ptr{Cvoid}
-
-"""
-    sc_keyvalue_foreach(kv, fn, user_data)
-
-Iterate through all stored key-value pairs.
-
-# Arguments
-* `kv`:\\[in\\] Valid key-value container.
-* `fn`:\\[in\\] Function to call on each key-value pair.
-* `user_data`:\\[in,out\\] This pointer is passed through to **fn**.
-### Prototype
-```c
-void sc_keyvalue_foreach (sc_keyvalue_t * kv, sc_keyvalue_foreach_t fn, void *user_data);
-```
-"""
-function sc_keyvalue_foreach(kv, fn, user_data)
-    @ccall libsc.sc_keyvalue_foreach(kv::Ptr{sc_keyvalue_t}, fn::sc_keyvalue_foreach_t, user_data::Ptr{Cvoid})::Cvoid
-end
-
-"""
-    sc_statinfo
-
-Store information of one random variable.
-
-| Field            | Note                                     |
-| :--------------- | :--------------------------------------- |
-| dirty            | Only update stats if this is true.       |
-| count            | Inout; global count is 52 bit accurate.  |
-| sum\\_values     | Inout; global sum of values.             |
-| sum\\_squares    | Inout; global sum of squares.            |
-| min              | Inout; minimum over values.              |
-| max              | Inout; maximum over values.              |
-| variable         | Name of the variable for output.         |
-| variable\\_owned | NULL or deep copy of variable.           |
-| group            | Grouping identifier.                     |
-| prio             | Priority identifier.                     |
-"""
-struct sc_statinfo
-    dirty::Cint
-    count::Clong
-    sum_values::Cdouble
-    sum_squares::Cdouble
-    min::Cdouble
-    max::Cdouble
-    min_at_rank::Cint
-    max_at_rank::Cint
-    average::Cdouble
-    variance::Cdouble
-    standev::Cdouble
-    variance_mean::Cdouble
-    standev_mean::Cdouble
-    variable::Cstring
-    variable_owned::Cstring
-    group::Cint
-    prio::Cint
-end
-
-"""Store information of one random variable."""
-const sc_statinfo_t = sc_statinfo
-
-struct sc_stats
-    mpicomm::MPI_Comm
-    kv::Ptr{sc_keyvalue_t}
-    sarray::Ptr{sc_array_t}
-end
-
-"""The statistics container allows dynamically adding random variables."""
-const sc_statistics_t = sc_stats
-
-"""
-    sc_stats_set1(stats, value, variable)
-
-Populate a [`sc_statinfo_t`](@ref) structure assuming count=1 and mark it dirty. We set sc_stats_group_all and sc_stats_prio_all internally.
-
-# Arguments
-* `stats`:\\[out\\] Will be filled with count=1 and the value.
-* `value`:\\[in\\] Value used to fill statistics information.
-* `variable`:\\[in\\] String to be reported by sc_stats_print. This string is assigned by pointer, not copied. Thus, it must stay alive while stats is in use.
-### Prototype
-```c
-void sc_stats_set1 (sc_statinfo_t * stats, double value, const char *variable);
-```
-"""
-function sc_stats_set1(stats, value, variable)
-    @ccall libsc.sc_stats_set1(stats::Ptr{sc_statinfo_t}, value::Cdouble, variable::Cstring)::Cvoid
-end
-
-"""
-    sc_stats_set1_ext(stats, value, variable, copy_variable, stats_group, stats_prio)
-
-Populate a [`sc_statinfo_t`](@ref) structure assuming count=1 and mark it dirty.
-
-# Arguments
-* `stats`:\\[out\\] Will be filled with count=1 and the value.
-* `value`:\\[in\\] Value used to fill statistics information.
-* `variable`:\\[in\\] String to be reported by sc_stats_print.
-* `copy_variable`:\\[in\\] If true, make internal copy of variable. Otherwise just assign the pointer.
-* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
-* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all.
-### Prototype
-```c
-void sc_stats_set1_ext (sc_statinfo_t * stats, double value, const char *variable, int copy_variable, int stats_group, int stats_prio);
-```
-"""
-function sc_stats_set1_ext(stats, value, variable, copy_variable, stats_group, stats_prio)
-    @ccall libsc.sc_stats_set1_ext(stats::Ptr{sc_statinfo_t}, value::Cdouble, variable::Cstring, copy_variable::Cint, stats_group::Cint, stats_prio::Cint)::Cvoid
-end
-
-"""
-    sc_stats_init(stats, variable)
-
-Initialize a [`sc_statinfo_t`](@ref) structure assuming count=0 and mark it dirty. This is useful if *stats* will be used to sc_stats_accumulate instances locally before global statistics are computed. We set sc_stats_group_all and sc_stats_prio_all internally.
-
-# Arguments
-* `stats`:\\[out\\] Will be filled with count 0 and values of 0.
-* `variable`:\\[in\\] String to be reported by sc_stats_print. This string is assigned by pointer, not copied. Thus, it must stay alive while stats is in use.
-### Prototype
-```c
-void sc_stats_init (sc_statinfo_t * stats, const char *variable);
-```
-"""
-function sc_stats_init(stats, variable)
-    @ccall libsc.sc_stats_init(stats::Ptr{sc_statinfo_t}, variable::Cstring)::Cvoid
-end
-
-"""
-    sc_stats_init_ext(stats, variable, copy_variable, stats_group, stats_prio)
-
-Initialize a [`sc_statinfo_t`](@ref) structure assuming count=0 and mark it dirty. This is useful if *stats* will be used to sc_stats_accumulate instances locally before global statistics are computed.
-
-# Arguments
-* `stats`:\\[out\\] Will be filled with count 0 and values of 0.
-* `variable`:\\[in\\] String to be reported by sc_stats_print.
-* `copy_variable`:\\[in\\] If true, make internal copy of variable. Otherwise just assign the pointer.
-* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
-* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all. Values increase by importance.
-### Prototype
-```c
-void sc_stats_init_ext (sc_statinfo_t * stats, const char *variable, int copy_variable, int stats_group, int stats_prio);
-```
-"""
-function sc_stats_init_ext(stats, variable, copy_variable, stats_group, stats_prio)
-    @ccall libsc.sc_stats_init_ext(stats::Ptr{sc_statinfo_t}, variable::Cstring, copy_variable::Cint, stats_group::Cint, stats_prio::Cint)::Cvoid
-end
-
-"""
-    sc_stats_reset(stats, reset_vgp)
-
-Reset all values to zero, optionally unassign name, group, and priority.
-
-# Arguments
-* `stats`:\\[in,out\\] Variables are zeroed. They can be set again by set1 or accumulate.
-* `reset_vgp`:\\[in\\] If true, the variable name string is zeroed and if we did a copy, the copy is freed. If true, group and priority are set to all. If false, we don't touch any of the above.
-### Prototype
-```c
-void sc_stats_reset (sc_statinfo_t * stats, int reset_vgp);
-```
-"""
-function sc_stats_reset(stats, reset_vgp)
-    @ccall libsc.sc_stats_reset(stats::Ptr{sc_statinfo_t}, reset_vgp::Cint)::Cvoid
-end
-
-"""
-    sc_stats_set_group_prio(stats, stats_group, stats_prio)
-
-Set/update the group and priority information for a stats item.
-
-# Arguments
-* `stats`:\\[out\\] Only group and stats entries are updated.
-* `stats_group`:\\[in\\] Non-negative number or sc_stats_group_all.
-* `stats_prio`:\\[in\\] Non-negative number or sc_stats_prio_all. Values increase by importance.
-### Prototype
-```c
-void sc_stats_set_group_prio (sc_statinfo_t * stats, int stats_group, int stats_prio);
-```
-"""
-function sc_stats_set_group_prio(stats, stats_group, stats_prio)
-    @ccall libsc.sc_stats_set_group_prio(stats::Ptr{sc_statinfo_t}, stats_group::Cint, stats_prio::Cint)::Cvoid
-end
-
-"""
-    sc_stats_accumulate(stats, value)
-
-Add an instance of the random variable. The counter of the variable is increased by one. The value is added into the present values of the variable.
-
-# Arguments
-* `stats`:\\[out\\] Must be dirty. We bump count and values.
-* `value`:\\[in\\] Value used to update statistics information.
-### Prototype
-```c
-void sc_stats_accumulate (sc_statinfo_t * stats, double value);
-```
-"""
-function sc_stats_accumulate(stats, value)
-    @ccall libsc.sc_stats_accumulate(stats::Ptr{sc_statinfo_t}, value::Cdouble)::Cvoid
-end
-
-"""
-    sc_stats_compute(mpicomm, nvars, stats)
-
-### Prototype
-```c
-void sc_stats_compute (sc_MPI_Comm mpicomm, int nvars, sc_statinfo_t * stats);
-```
-"""
-function sc_stats_compute(mpicomm, nvars, stats)
-    @ccall libsc.sc_stats_compute(mpicomm::MPI_Comm, nvars::Cint, stats::Ptr{sc_statinfo_t})::Cvoid
-end
-
-"""
-    sc_stats_compute1(mpicomm, nvars, stats)
-
-### Prototype
-```c
-void sc_stats_compute1 (sc_MPI_Comm mpicomm, int nvars, sc_statinfo_t * stats);
-```
-"""
-function sc_stats_compute1(mpicomm, nvars, stats)
-    @ccall libsc.sc_stats_compute1(mpicomm::MPI_Comm, nvars::Cint, stats::Ptr{sc_statinfo_t})::Cvoid
-end
-
-"""
-    sc_stats_print(package_id, log_priority, nvars, stats, full, summary)
-
-Print measured statistics. This function uses the [`SC_LC_GLOBAL`](@ref) log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler. All groups and priorities are printed.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `log_priority`:\\[in\\] Log priority for output according to sc.h.
-* `nvars`:\\[in\\] Number of stats items in input array.
-* `stats`:\\[in\\] Input array of stats variable items.
-* `full`:\\[in\\] Print full information for every variable.
-* `summary`:\\[in\\] Print summary information all on 1 line.
-### Prototype
-```c
-void sc_stats_print (int package_id, int log_priority, int nvars, sc_statinfo_t * stats, int full, int summary);
-```
-"""
-function sc_stats_print(package_id, log_priority, nvars, stats, full, summary)
-    @ccall libsc.sc_stats_print(package_id::Cint, log_priority::Cint, nvars::Cint, stats::Ptr{sc_statinfo_t}, full::Cint, summary::Cint)::Cvoid
-end
-
-"""
-    sc_stats_print_ext(package_id, log_priority, nvars, stats, stats_group, stats_prio, full, summary)
-
-Print measured statistics, filter by group and/or priority. This function uses the [`SC_LC_GLOBAL`](@ref) log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `log_priority`:\\[in\\] Log priority for output according to sc.h.
-* `nvars`:\\[in\\] Number of stats items in input array.
-* `stats`:\\[in\\] Input array of stats variable items.
-* `stats_group`:\\[in\\] Print only this group. Non-negative or sc_stats_group_all. We skip printing a variable if neither this parameter nor the item's group is all and if the item's group does not match this.
-* `stats_prio`:\\[in\\] Print this and higher priorities. Non-negative or sc_stats_prio_all. We skip printing a variable if neither this parameter nor the item's prio is all and if the item's prio is less than this.
-* `full`:\\[in\\] Print full information for every variable. This produces multiple lines including minimum, maximum, and standard deviation. If this is false, print one line per variable.
-* `summary`:\\[in\\] Print summary information all on 1 line. This always contains all variables. Not affected by stats\\_group and stats\\_prio.
-### Prototype
-```c
-void sc_stats_print_ext (int package_id, int log_priority, int nvars, sc_statinfo_t * stats, int stats_group, int stats_prio, int full, int summary);
-```
-"""
-function sc_stats_print_ext(package_id, log_priority, nvars, stats, stats_group, stats_prio, full, summary)
-    @ccall libsc.sc_stats_print_ext(package_id::Cint, log_priority::Cint, nvars::Cint, stats::Ptr{sc_statinfo_t}, stats_group::Cint, stats_prio::Cint, full::Cint, summary::Cint)::Cvoid
-end
-
-"""
-    sc_statistics_new(mpicomm)
-
-### Prototype
-```c
-sc_statistics_t *sc_statistics_new (sc_MPI_Comm mpicomm);
-```
-"""
-function sc_statistics_new(mpicomm)
-    @ccall libsc.sc_statistics_new(mpicomm::MPI_Comm)::Ptr{sc_statistics_t}
-end
-
-"""
-    sc_statistics_destroy(stats)
-
-Destroy a statistics structure.
-
-# Arguments
-* `stats`:\\[in,out\\] Valid object is invalidated.
-### Prototype
-```c
-void sc_statistics_destroy (sc_statistics_t * stats);
-```
-"""
-function sc_statistics_destroy(stats)
-    @ccall libsc.sc_statistics_destroy(stats::Ptr{sc_statistics_t})::Cvoid
-end
-
-"""
-    sc_statistics_add(stats, name)
-
-Register a statistics variable by name and set its value to 0. This variable must not exist already.
-
-### Prototype
-```c
-void sc_statistics_add (sc_statistics_t * stats, const char *name);
-```
-"""
-function sc_statistics_add(stats, name)
-    @ccall libsc.sc_statistics_add(stats::Ptr{sc_statistics_t}, name::Cstring)::Cvoid
-end
-
-"""
-    sc_statistics_add_empty(stats, name)
-
-Register a statistics variable by name and set its count to 0. This variable must not exist already.
-
-### Prototype
-```c
-void sc_statistics_add_empty (sc_statistics_t * stats, const char *name);
-```
-"""
-function sc_statistics_add_empty(stats, name)
-    @ccall libsc.sc_statistics_add_empty(stats::Ptr{sc_statistics_t}, name::Cstring)::Cvoid
-end
-
-"""
-    sc_statistics_has(stats, name)
-
-Returns true if the stats include a variable with the given name
-
-### Prototype
-```c
-int sc_statistics_has (sc_statistics_t * stats, const char *name);
-```
-"""
-function sc_statistics_has(stats, name)
-    @ccall libsc.sc_statistics_has(stats::Ptr{sc_statistics_t}, name::Cstring)::Cint
-end
-
-"""
-    sc_statistics_set(stats, name, value)
-
-Set the value of a statistics variable, see [`sc_stats_set1`](@ref). The variable must previously be added with [`sc_statistics_add`](@ref). This assumes count=1 as in the [`sc_stats_set1`](@ref) function above.
-
-### Prototype
-```c
-void sc_statistics_set (sc_statistics_t * stats, const char *name, double value);
-```
-"""
-function sc_statistics_set(stats, name, value)
-    @ccall libsc.sc_statistics_set(stats::Ptr{sc_statistics_t}, name::Cstring, value::Cdouble)::Cvoid
-end
-
-"""
-    sc_statistics_accumulate(stats, name, value)
-
-Add an instance of a statistics variable, see [`sc_stats_accumulate`](@ref) The variable must previously be added with [`sc_statistics_add_empty`](@ref).
-
-### Prototype
-```c
-void sc_statistics_accumulate (sc_statistics_t * stats, const char *name, double value);
-```
-"""
-function sc_statistics_accumulate(stats, name, value)
-    @ccall libsc.sc_statistics_accumulate(stats::Ptr{sc_statistics_t}, name::Cstring, value::Cdouble)::Cvoid
-end
-
-"""
-    sc_statistics_compute(stats)
-
-Compute statistics for all variables, see [`sc_stats_compute`](@ref).
-
-### Prototype
-```c
-void sc_statistics_compute (sc_statistics_t * stats);
-```
-"""
-function sc_statistics_compute(stats)
-    @ccall libsc.sc_statistics_compute(stats::Ptr{sc_statistics_t})::Cvoid
-end
-
-"""
-    sc_statistics_print(stats, package_id, log_priority, full, summary)
-
-Print all statistics variables, see [`sc_stats_print`](@ref).
-
-### Prototype
-```c
-void sc_statistics_print (sc_statistics_t * stats, int package_id, int log_priority, int full, int summary);
-```
-"""
-function sc_statistics_print(stats, package_id, log_priority, full, summary)
-    @ccall libsc.sc_statistics_print(stats::Ptr{sc_statistics_t}, package_id::Cint, log_priority::Cint, full::Cint, summary::Cint)::Cvoid
-end
-
-"""
-    t8_forest
-
-| Field                          | Note                                                                                                                                                                                                                                                                                           |
-| :----------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| rc                             | Reference counter.                                                                                                                                                                                                                                                                             |
-| set\\_partition\\_offset       | Flag indicating whether the partition range was set manually.                                                                                                                                                                                                                                  |
-| set\\_first\\_global\\_element | If set\\_partition\\_offset is true, the global ID of the first local element after partitioning.                                                                                                                                                                                              |
-| set\\_level                    | Level to use in new construction.                                                                                                                                                                                                                                                              |
-| set\\_for\\_coarsening         | Change partition to allow for one round of coarsening                                                                                                                                                                                                                                          |
-| weight\\_function              | Pointer to user defined element weight function. Nullptr for standard, element-based partitioning.                                                                                                                                                                                             |
-| cmesh                          | Coarse mesh to use.                                                                                                                                                                                                                                                                            |
-| scheme                         | Scheme for element types.                                                                                                                                                                                                                                                                      |
-| maxlevel                       | The maximum allowed refinement level for elements in this forest.                                                                                                                                                                                                                              |
-| maxlevel\\_existing            | If >= 0, the maximum occurring refinement level of a forest element.                                                                                                                                                                                                                           |
-| do\\_dup                       | Communicator shall be duped.                                                                                                                                                                                                                                                                   |
-| dimension                      | Dimension inferred from **cmesh**.                                                                                                                                                                                                                                                             |
-| incomplete\\_trees             | Flag to check whether the forest has (potential) incomplete trees. A tree is incomplete if an element has been removed from it. Once an element got removed, the flag sets to 1 (true) and stays. For a committed forest this flag is either true on all ranks or false on all ranks.          |
-| set\\_from                     | Temporarily store source forest.                                                                                                                                                                                                                                                               |
-| from\\_method                  | Method to derive from **set_from**.                                                                                                                                                                                                                                                            |
-| set\\_adapt\\_fn               | refinement and coarsen function. Called when **from_method** is set to [`T8_FOREST_FROM_ADAPT`](@ref).                                                                                                                                                                                         |
-| set\\_adapt\\_recursive        | Flag to decide whether coarsen and refine are carried out recursive                                                                                                                                                                                                                            |
-| set\\_balance                  | Flag to decide whether to forest will be balance in t8_forest_commit. See t8_forest_set_balance. If 0, no balance. If 1 balance with repartitioning, if 2 balance without repartitioning,  # See also t8\\_forest\\_balance                                                                    |
-| do\\_ghost                     | If True, a ghost layer will be created when the forest is committed.                                                                                                                                                                                                                           |
-| ghost\\_type                   | If a ghost layer will be created, the type of neighbors that count as ghost.                                                                                                                                                                                                                   |
-| ghost\\_algorithm              | Controls the algorithm used for ghost. 1 = balanced only. 2 = also unbalanced 3 = top-down search and unbalanced.                                                                                                                                                                              |
-| user\\_data                    | Pointer for arbitrary user data.  # See also [`t8_forest_set_user_data`](@ref).                                                                                                                                                                                                                |
-| user\\_function                | Pointer for arbitrary user function.  # See also [`t8_forest_set_user_function`](@ref).                                                                                                                                                                                                        |
-| t8code\\_data                  | Pointer for arbitrary data that is used internally.                                                                                                                                                                                                                                            |
-| committed                      | t8_forest_commit called?                                                                                                                                                                                                                                                                       |
-| mpisize                        | Number of MPI processes.                                                                                                                                                                                                                                                                       |
-| mpirank                        | Number of this MPI process.                                                                                                                                                                                                                                                                    |
-| first\\_local\\_tree           | The global index of the first local tree on this process. If first\\_local\\_tree is larger than last\\_local\\_tree then this processor/forest is empty. See https://github.com/DLR-AMR/t8code/wiki/Tree-indexing                                                                             |
-| last\\_local\\_tree            | The global index of the last local tree on this process. -1 if this processor is empty.                                                                                                                                                                                                        |
-| global\\_num\\_trees           | The total number of global trees.                                                                                                                                                                                                                                                              |
-| trees                          | The array of trees.                                                                                                                                                                                                                                                                            |
-| ghosts                         | If not NULL, the ghost elements.  # See also [`t8_forest_ghost`](@ref).h                                                                                                                                                                                                                       |
-| element\\_offsets              | If partitioned, for each process the global index of its first element. Since it is memory consuming, it is usually only constructed when needed and otherwise unallocated.                                                                                                                    |
-| global\\_first\\_desc          | If partitioned, for each process the linear id (at maxlevel) of its first element's first descendant. t8_element_set_linear_id. Stores 0 for empty processes. Since it is memory consuming, it is usually only constructed when needed and otherwise unallocated.                              |
-| tree\\_offsets                 | If partitioned for each process the global index of its first local tree or -(first local tree) - 1 if the first tree on that process is shared. Since this is memory consuming we only construct it when needed. This array follows the same logic as *tree_offsets* in [`t8_cmesh_t`](@ref)  |
-| local\\_num\\_leaf\\_elements  | Number of leaf elements on this processor.                                                                                                                                                                                                                                                     |
-| global\\_num\\_leaf\\_elements | Number of leaf elements on all processors.                                                                                                                                                                                                                                                     |
-| profile                        | If not NULL, runtimes and statistics about forest\\_commit are stored here.                                                                                                                                                                                                                    |
-| stats                          | The SC profiling stats of the forest.                                                                                                                                                                                                                                                          |
-| stats\\_computed               | Switch indicating whether the profiling stats have been compute (1) or not (0)                                                                                                                                                                                                                 |
-"""
-# This struct is not supposed to be read and modified directly.
-# Besides, there is a circular dependency with `t8_forest_t`
-# leading to an error output by Julia.
-mutable struct t8_forest end
-
-"""Opaque pointer to a forest implementation."""
-const t8_forest_t = Ptr{t8_forest}
-
-"""
     t8_forest_adapt(forest)
 
-Adapt a forest.
-
-# Arguments
-* `forest`:\\[in,out\\] The forest to be adapted
 ### Prototype
 ```c
 void t8_forest_adapt (t8_forest_t forest);
@@ -10519,27 +14742,50 @@ function t8_forest_adapt(forest)
 end
 
 """
+    t8_forest_balance(forest, repartition)
+
+### Prototype
+```c
+void t8_forest_balance (t8_forest_t forest, int repartition);
+```
+"""
+function t8_forest_balance(forest, repartition)
+    @ccall libt8.t8_forest_balance(forest::t8_forest_t, repartition::Cint)::Cvoid
+end
+
+"""
+    t8_forest_is_balanced(forest)
+
+### Prototype
+```c
+int t8_forest_is_balanced (t8_forest_t forest);
+```
+"""
+function t8_forest_is_balanced(forest)
+    @ccall libt8.t8_forest_is_balanced(forest::t8_forest_t)::Cint
+end
+
+"""
     t8_tree
 
 The t8 tree datatype
 
 | Field             | Note                                                               |
 | :---------------- | :----------------------------------------------------------------- |
-| leaf\\_elements   | locally stored leaf elements                                       |
+| elements          | locally stored elements                                            |
 | eclass            | The element class of this tree                                     |
 | first\\_desc      | first local descendant                                             |
 | last\\_desc       | last local descendant                                              |
 | elements\\_offset | cumulative sum over earlier trees on this processor (locals only)  |
 """
 struct t8_tree
-    leaf_elements::t8_element_array_t
+    elements::t8_element_array_t
     eclass::t8_eclass_t
     first_desc::Ptr{t8_element_t}
     last_desc::Ptr{t8_element_t}
     elements_offset::t8_locidx_t
 end
 
-"""Opaque pointer to a tree implementation."""
 const t8_tree_t = Ptr{t8_tree}
 
 """
@@ -10563,31 +14809,26 @@ end
 
 # typedef void ( * t8_generic_function_pointer ) ( void )
 """
-This typedef is needed as a helper construct to properly be able to define a function that returns a pointer to a void fun(void) function.
+This typedef is needed as a helper construct to  properly be able to define a function that returns a pointer to a void fun(void) function.
 
 # See also
 [`t8_forest_get_user_function`](@ref).
 """
 const t8_generic_function_pointer = Ptr{Cvoid}
 
-# typedef double ( t8_weight_fcn_t ) ( t8_forest_t , t8_locidx_t , t8_locidx_t )
-"""The prototype of a weight function for the partition algorithm. The function should be pure, and return a positive weight given a forest, a local tree index and an element index within the local tree"""
-const t8_weight_fcn_t = Cvoid
-
-# typedef void ( * t8_forest_replace_t ) ( t8_forest_t forest_old , t8_forest_t forest_new , t8_locidx_t which_tree , const t8_eclass_t tree_class , const t8_scheme_c * scheme , const int refine , const int num_outgoing , const t8_locidx_t first_outgoing , const int num_incoming , const t8_locidx_t first_incoming )
+# typedef void ( * t8_forest_replace_t ) ( t8_forest_t forest_old , t8_forest_t forest_new , t8_locidx_t which_tree , t8_eclass_scheme_c * ts , const int refine , const int num_outgoing , const t8_locidx_t first_outgoing , const int num_incoming , const t8_locidx_t first_incoming )
 """
 Callback function prototype to replace one set of elements with another.
 
 This is used by the replace routine which can be called after adapt, when the elements of an existing, valid forest are changed. The callback allows the user to make changes to the elements of the new forest that are either refined, coarsened or the same as elements in the old forest.
 
-If an element is being refined, *refine* and *num_outgoing* will be 1 and *num_incoming* will be the number of children. If a family is being coarsened, *refine* will be -1, *num_outgoing* will be the number of family members and *num_incoming* will be 1. If an element is being removed, *refine* and *num_outgoing* will be 1 and *num_incoming* will be 0. Else *refine* will be 0 and *num_outgoing* and *num_incoming* will both be 1.
+If an element is being refined, *refine* and *num_outgoing* will be 1 and  *num_incoming* will be the number of children. If a family is being coarsened, *refine* will be -1, *num_outgoing* will be  the number of family members and *num_incoming* will be 1.  If an element is being removed, *refine* and *num_outgoing* will be 1 and  *num_incoming* will be 0.  Else *refine* will be 0 and *num_outgoing* and *num_incoming* will both be 1.
 
 # Arguments
 * `forest_old`:\\[in\\] The forest that is adapted
-* `forest_new`:\\[in,out\\] The forest that is newly constructed from *forest_old*
+* `forest_new`:\\[in\\] The forest that is newly constructed from *forest_old*
 * `which_tree`:\\[in\\] The local tree containing *first_outgoing* and *first_incoming*
-* `tree_class`:\\[in\\] The eclass of the local tree containing *first_outgoing* and *first_incoming*
-* `scheme`:\\[in\\] The scheme of the forest
+* `ts`:\\[in\\] The eclass scheme of the tree
 * `refine`:\\[in\\] -1 if family in *forest_old* got coarsened, 0 if element has not been touched, 1 if element got refined and -2 if element got removed. See return of [`t8_forest_adapt_t`](@ref).
 * `num_outgoing`:\\[in\\] The number of outgoing elements.
 * `first_outgoing`:\\[in\\] The tree local index of the first outgoing element. 0 <= first\\_outgoing < which\\_tree->num\\_elements
@@ -10598,19 +14839,18 @@ If an element is being refined, *refine* and *num_outgoing* will be 1 and *num_i
 """
 const t8_forest_replace_t = Ptr{Cvoid}
 
-# typedef int ( * t8_forest_adapt_t ) ( t8_forest_t forest , t8_forest_t forest_from , t8_locidx_t which_tree , const t8_eclass_t tree_class , t8_locidx_t lelement_id , const t8_scheme_c * scheme , const int is_family , const int num_elements , t8_element_t * elements [ ] )
+# typedef int ( * t8_forest_adapt_t ) ( t8_forest_t forest , t8_forest_t forest_from , t8_locidx_t which_tree , t8_locidx_t lelement_id , t8_eclass_scheme_c * ts , const int is_family , const int num_elements , t8_element_t * elements [ ] )
 """
-Callback function prototype to decide for refining and coarsening. If *is_family* equals 1, the first *num_elements* in *elements* form a family and we decide whether this family should be coarsened or only the first element should be refined. Otherwise *is_family* must equal zero and we consider the first entry of the element array for refinement. Entries of the element array beyond the first *num_elements* are undefined.
+Callback function prototype to decide for refining and coarsening. If *is_family* equals 1, the first *num_elements* in *elements* form a family and we decide whether this family should be coarsened or only the first element should be refined. Otherwise *is_family* must equal zero and we consider the first entry of the element array for refinement.  Entries of the element array beyond the first *num_elements* are undefined.
 
 # Arguments
-* `forest`:\\[in\\] The forest to which the new elements belong.
-* `forest_from`:\\[in\\] The forest that is adapted.
-* `which_tree`:\\[in\\] The local tree containing *elements*.
-* `tree_class`:\\[in\\] The eclass of *which_tree*.
-* `lelement_id`:\\[in\\] The local element id in *forest_from* in the tree of the current element.
-* `scheme`:\\[in\\] The scheme of the forest.
-* `is_family`:\\[in\\] If 1, the first *num_elements* entries in *elements* form a family. If 0, they do not.
-* `num_elements`:\\[in\\] The number of entries in *elements* that are defined
+* `forest`:\\[in\\] the forest to which the new elements belong
+* `forest_from`:\\[in\\] the forest that is adapted.
+* `which_tree`:\\[in\\] the local tree containing *elements*
+* `lelement_id`:\\[in\\] the local element id in *forest_old* in the tree of the current element
+* `ts`:\\[in\\] the eclass scheme of the tree
+* `is_family`:\\[in\\] if 1, the first *num_elements* entries in *elements* form a family. If 0, they do not.
+* `num_elements`:\\[in\\] the number of entries in *elements* that are defined
 * `elements`:\\[in\\] Pointers to a family or, if *is_family* is zero, pointer to one element.
 # Returns
 1 if the first entry in *elements* should be refined, -1 if the family *elements* shall be coarsened, -2 if the first entry in *elements* should be removed, 0 else.
@@ -10620,13 +14860,10 @@ const t8_forest_adapt_t = Ptr{Cvoid}
 """
     t8_forest_init(pforest)
 
-Create a new forest with reference count one. This forest needs to be specialized with the t8\\_forest\\_set\\_* calls. Currently it is mandatory to either call the functions
+Create a new forest with reference count one. This forest needs to be specialized with the t8\\_forest\\_set\\_* calls. Currently it is mandatory to either call the functions t8_forest_set_mpicomm, t8_forest_set_cmesh, and t8_forest_set_scheme, or to call one of t8_forest_set_copy, t8_forest_set_adapt, or t8_forest_set_partition. It is illegal to mix these calls, or to call more than one of the three latter functions Then it needs to be set up with t8_forest_commit.
 
 # Arguments
 * `pforest`:\\[in,out\\] On input, this pointer must be non-NULL. On return, this pointer set to the new forest.
-# See also
-t8\\_forest\\_set\\_mpicomm, t8_forest_set_cmesh, and t8_forest_set_scheme, or to call one of t8_forest_set_copy, t8_forest_set_adapt, or t8_forest_set_partition. It is illegal to mix these calls, or to call more than one of the three latter functions Then it needs to be set up with t8_forest_commit.
-
 ### Prototype
 ```c
 void t8_forest_init (t8_forest_t *pforest);
@@ -10686,7 +14923,7 @@ Check whether the forest has local overlapping elements.
 # Returns
 True if *forest* has no elements which are inside each other.
 # See also
-[`t8_forest_partition_test_boundary_element`](@ref) if you also want to test for global overlap across the process boundaries.
+[`t8_forest_partition_test_boundary_element`](@ref) if you also want to test for  global overlap across the process boundaries.
 
 ### Prototype
 ```c
@@ -10710,7 +14947,7 @@ Check whether two committed forests have the same local elements.
 * `forest_a`:\\[in\\] The first forest.
 * `forest_b`:\\[in\\] The second forest.
 # Returns
-True if *forest_a* and *forest_b* do have the same number of local trees and each local tree has the same elements, that is t8_element_is_equal returns true for each pair of elements of *forest_a* and *forest_b*.
+True if *forest_a* and *forest_b* do have the same number of local trees and each local tree has the same elements, that is t8_element_equal returns true for each pair of elements of *forest_a* and *forest_b*.
 ### Prototype
 ```c
 int t8_forest_is_equal (t8_forest_t forest_a, t8_forest_t forest_b);
@@ -10742,11 +14979,11 @@ Set the element scheme associated to a forest. By default, the forest takes owne
 * `scheme`:\\[in\\] The scheme to be set. We take ownership. This can be prevented by referencing **scheme**.
 ### Prototype
 ```c
-void t8_forest_set_scheme (t8_forest_t forest, const t8_scheme_c *scheme);
+void t8_forest_set_scheme (t8_forest_t forest, t8_scheme_cxx_t *scheme);
 ```
 """
 function t8_forest_set_scheme(forest, scheme)
-    @ccall libt8.t8_forest_set_scheme(forest::t8_forest_t, scheme::Ptr{t8_scheme_c})::Cvoid
+    @ccall libt8.t8_forest_set_scheme(forest::t8_forest_t, scheme::Ptr{t8_scheme_cxx_t})::Cvoid
 end
 
 """
@@ -10798,7 +15035,7 @@ Set a source forest with an adapt function to be adapted on committing. By defau
 
 !!! note
 
-    This setting can be combined with t8_forest_set_partition and t8_forest_set_balance. The order in which these operations are executed is always 1) Adapt 2) Partition 3) Balance.
+    This setting can be combined with t8_forest_set_partition and t8_forest_set_balance. The order in which these operations are executed is always 1) Adapt 2) Balance 3) Partition
 
 !!! note
 
@@ -10811,7 +15048,7 @@ Set a source forest with an adapt function to be adapted on committing. By defau
 * `recursive`:\\[in\\] A flag specifying whether adaptation is to be done recursively or not. If the value is zero, adaptation is not recursive and it is recursive otherwise.
 ### Prototype
 ```c
-void t8_forest_set_adapt (t8_forest_t forest, const t8_forest_t set_from, t8_forest_adapt_t adapt_fn, const int recursive);
+void t8_forest_set_adapt (t8_forest_t forest, const t8_forest_t set_from, t8_forest_adapt_t adapt_fn, int recursive);
 ```
 """
 function t8_forest_set_adapt(forest, set_from, adapt_fn, recursive)
@@ -10911,7 +15148,7 @@ Set a source forest to be partitioned during commit. The partitioning is done ac
 
 !!! note
 
-    This setting can be combined with t8_forest_set_adapt and t8_forest_set_balance. The order in which these operations are executed is always 1) Adapt 2) Partition 3) Balance. If t8_forest_set_balance is called with the *no_repartition* parameter set as false, it is not necessary to call t8_forest_set_partition additionally.
+    This setting can be combined with t8_forest_set_adapt and t8_forest_set_balance. The order in which these operations are executed is always 1) Adapt 2) Balance 3) Partition If t8_forest_set_balance is called with the *no_repartition* parameter set as false, it is not necessary to call t8_forest_set_partition additionally.
 
 !!! note
 
@@ -10920,7 +15157,7 @@ Set a source forest to be partitioned during commit. The partitioning is done ac
 # Arguments
 * `forest`:\\[in,out\\] The forest.
 * `set_from`:\\[in\\] A second forest that should be partitioned. We take ownership. This can be prevented by referencing **set_from**. If NULL, a previously (or later) set forest will be taken (t8_forest_set_adapt, t8_forest_set_balance).
-* `set_for_coarsening`:\\[in\\] If true, the partition will be such that coarsening a family of elements into their parent once is a process-local operation. This is ensured by a post-processing step that slightly shifts the newly determined process boundaries such that no full family of (same-level) siblings is split between processes.
+* `set_for_coarsening`:\\[in\\] CURRENTLY DISABLED. If true, then the partitions are choose such that coarsening an element once is a process local operation.
 ### Prototype
 ```c
 void t8_forest_set_partition (t8_forest_t forest, const t8_forest_t set_from, int set_for_coarsening);
@@ -10931,36 +15168,13 @@ function t8_forest_set_partition(forest, set_from, set_for_coarsening)
 end
 
 """
-    t8_forest_set_partition_weight_function(forest, weight_callback)
-
-Set a user-defined weight function to guide the partitioning.
-
-\\pre *weight_callback* must be free of side effects (like changing the forest, some global state, etc.), the behavior is undefined otherwise.
-
-!!! note
-
-    If *weight_callback* is null, then all the elements are assumed to have the same weight
-
-# Arguments
-* `forest`:\\[in,out\\] The forest.
-* `weight_callback`:\\[in\\] A callback function defining element weights for the partitioning.
-### Prototype
-```c
-void t8_forest_set_partition_weight_function (t8_forest_t forest, t8_weight_fcn_t *weight_callback);
-```
-"""
-function t8_forest_set_partition_weight_function(forest, weight_callback)
-    @ccall libt8.t8_forest_set_partition_weight_function(forest::t8_forest_t, weight_callback::Ptr{t8_weight_fcn_t})::Cvoid
-end
-
-"""
     t8_forest_set_balance(forest, set_from, no_repartition)
 
 Set a source forest to be balanced during commit. A forest is said to be balanced if each element has face neighbors of level at most +1 or -1 of the element's level.
 
 !!! note
 
-    This setting can be combined with t8_forest_set_adapt and t8_forest_set_partition. The order in which these operations are executed is always 1) Adapt 2) Partition 3) Balance.
+    This setting can be combined with t8_forest_set_adapt and t8_forest_set_balance. The order in which these operations are executed is always 1) Adapt 2) Balance 3) Partition.
 
 !!! note
 
@@ -11003,9 +15217,6 @@ end
 Like t8_forest_set_ghost but with the additional options to change the ghost algorithm. This is used for debugging and timing the algorithm. An application should almost always use t8_forest_set_ghost.
 
 # Arguments
-* `forest`:\\[in\\] The forest.
-* `do_ghost`:\\[in\\] If non-zero a ghost layer will be created.
-* `ghost_type`:\\[in\\] Controls which neighbors count as ghost elements, currently only T8\\_GHOST\\_FACES is supported. This value is ignored if *do_ghost* = 0.
 * `ghost_version`:\\[in\\] If 1, the iterative ghost algorithm for balanced forests is used. If 2, the iterative algorithm for unbalanced forests. If 3, the top-down search algorithm for unbalanced forests.
 # See also
 [`t8_forest_set_ghost`](@ref)
@@ -11022,10 +15233,6 @@ end
 """
     t8_forest_set_load(forest, filename)
 
-Use assertions and document that the forest\\_set (..., from) and set\\_load are mutually exclusive.
-
-TODO: Unused function -> remove?
-
 ### Prototype
 ```c
 void t8_forest_set_load (t8_forest_t forest, const char *filename);
@@ -11036,19 +15243,19 @@ function t8_forest_set_load(forest, filename)
 end
 
 """
-    t8_forest_comm_global_num_leaf_elements(forest)
+    t8_forest_comm_global_num_elements(forest)
 
-Compute the global number of leaf elements in a forest as the sum of the local leaf element counts.
+Compute the global number of elements in a forest as the sum of the local element counts.
 
 # Arguments
 * `forest`:\\[in\\] The forest.
 ### Prototype
 ```c
-void t8_forest_comm_global_num_leaf_elements (t8_forest_t forest);
+void t8_forest_comm_global_num_elements (t8_forest_t forest);
 ```
 """
-function t8_forest_comm_global_num_leaf_elements(forest)
-    @ccall libt8.t8_forest_comm_global_num_leaf_elements(forest::t8_forest_t)::Cvoid
+function t8_forest_comm_global_num_elements(forest)
+    @ccall libt8.t8_forest_comm_global_num_elements(forest::t8_forest_t)::Cvoid
 end
 
 """
@@ -11086,39 +15293,39 @@ function t8_forest_get_maxlevel(forest)
 end
 
 """
-    t8_forest_get_local_num_leaf_elements(forest)
+    t8_forest_get_local_num_elements(forest)
 
-Return the number of process local leaf elements in the forest.
+Return the number of process local elements in the forest.
 
 # Arguments
 * `forest`:\\[in\\] A forest.
 # Returns
-The number of leaf elements on this process in *forest*. *forest* must be committed before calling this function.
+The number of elements on this process in *forest*. *forest* must be committed before calling this function.
 ### Prototype
 ```c
-t8_locidx_t t8_forest_get_local_num_leaf_elements (const t8_forest_t forest);
+t8_locidx_t t8_forest_get_local_num_elements (const t8_forest_t forest);
 ```
 """
-function t8_forest_get_local_num_leaf_elements(forest)
-    @ccall libt8.t8_forest_get_local_num_leaf_elements(forest::t8_forest_t)::t8_locidx_t
+function t8_forest_get_local_num_elements(forest)
+    @ccall libt8.t8_forest_get_local_num_elements(forest::t8_forest_t)::t8_locidx_t
 end
 
 """
-    t8_forest_get_global_num_leaf_elements(forest)
+    t8_forest_get_global_num_elements(forest)
 
-Return the number of global leaf elements in the forest.
+Return the number of global elements in the forest.
 
 # Arguments
 * `forest`:\\[in\\] A forest.
 # Returns
-The number of leaf elements (summed over all processes) in *forest*. *forest* must be committed before calling this function.
+The number of elements (summed over all processes) in *forest*. *forest* must be committed before calling this function.
 ### Prototype
 ```c
-t8_gloidx_t t8_forest_get_global_num_leaf_elements (const t8_forest_t forest);
+t8_gloidx_t t8_forest_get_global_num_elements (const t8_forest_t forest);
 ```
 """
-function t8_forest_get_global_num_leaf_elements(forest)
-    @ccall libt8.t8_forest_get_global_num_leaf_elements(forest::t8_forest_t)::t8_gloidx_t
+function t8_forest_get_global_num_elements(forest)
+    @ccall libt8.t8_forest_get_global_num_elements(forest::t8_forest_t)::t8_gloidx_t
 end
 
 """
@@ -11189,9 +15396,9 @@ Given a global tree id compute the forest local id of this tree. If the tree is 
 * `forest`:\\[in\\] The forest.
 * `gtreeid`:\\[in\\] The global id of a tree.
 # Returns
-The tree's local id in *forest*, if it is a local tree. A negative number if not. Ghosts trees are not considered as local.
+The tree's local id in *forest*, if it is a local tree. A negative number if not.
 # See also
-[`t8_forest_get_local_or_ghost_id`](@ref) for ghost trees., https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
+https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
 
 ### Prototype
 ```c
@@ -11213,7 +15420,7 @@ Given a global tree id compute the forest local id of this tree. If the tree is 
 # Returns
 The tree's local id in *forest*, if it is a local tree. num\\_local\\_trees + the ghosts id, if it is a ghost tree. A negative number if not.
 # See also
-https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing
+https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
 
 ### Prototype
 ```c
@@ -11261,7 +15468,7 @@ Given the local id of a tree in the coarse mesh of a forest, compute the tree's 
 
 # Arguments
 * `forest`:\\[in\\] The forest.
-* `lctreeid`:\\[in\\] The local id of a tree in the coarse mesh of *forest*.
+* `ltreeid`:\\[in\\] The local id of a tree in the coarse mesh of *forest*.
 # Returns
 The local id of the tree in the forest. -1 if the tree is not forest local. *forest* must be committed before calling this function.
 # See also
@@ -11324,32 +15531,7 @@ function t8_forest_element_is_leaf(forest, element, local_tree)
 end
 
 """
-    t8_forest_element_is_leaf_or_ghost(forest, element, local_tree, check_ghost)
-
-Query whether a given element or a ghost is a leaf of a local or ghost tree in a forest.
-
-!!! note
-
-    *forest* must be committed before calling this function. t8_forest_element_is_leaf t8_forest_element_is_ghost
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `element`:\\[in\\] An element of a local tree in *forest*.
-* `local_tree`:\\[in\\] A local tree id of *forest* or a ghost tree id
-* `check_ghost`:\\[in\\] If true *element* is interpreted as a ghost element and *local_tree* as the id of a ghost tree (0 <= *local_tree* < num\\_ghost\\_trees). If false *element* is interpreted as an element and *local_tree* as the id of a local tree (0 <= *local_tree* < num\\_local\\_trees).
-# Returns
-True (non-zero) if and only if *element* is a leaf (or ghost) in *local_tree* of *forest*.
-### Prototype
-```c
-int t8_forest_element_is_leaf_or_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t local_tree, const int check_ghost);
-```
-"""
-function t8_forest_element_is_leaf_or_ghost(forest, element, local_tree, check_ghost)
-    @ccall libt8.t8_forest_element_is_leaf_or_ghost(forest::t8_forest_t, element::Ptr{t8_element_t}, local_tree::t8_locidx_t, check_ghost::Cint)::Cint
-end
-
-"""
-    t8_forest_leaf_face_orientation(forest, ltreeid, scheme, leaf, face)
+    t8_forest_leaf_face_orientation(forest, ltreeid, ts, leaf, face)
 
 Compute the leaf face orientation at given face in a forest.
 
@@ -11358,22 +15540,22 @@ For more information about the encoding of face orientation refer to t8_cmesh_ge
 # Arguments
 * `forest`:\\[in\\] The forest. Must have a valid ghost layer.
 * `ltreeid`:\\[in\\] A local tree id.
-* `scheme`:\\[in\\] The eclass scheme of the element.
+* `ts`:\\[in\\] The eclass scheme of the element.
 * `leaf`:\\[in\\] A leaf in tree *ltreeid* of *forest*.
 * `face`:\\[in\\] The index of the face across which the face neighbors are searched.
 # Returns
 Face orientation encoded as integer.
 ### Prototype
 ```c
-int t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_scheme_c *scheme, const t8_element_t *leaf, const int face);
+int t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts, const t8_element_t *leaf, int face);
 ```
 """
-function t8_forest_leaf_face_orientation(forest, ltreeid, scheme, leaf, face)
-    @ccall libt8.t8_forest_leaf_face_orientation(forest::t8_forest_t, ltreeid::t8_locidx_t, scheme::Ptr{t8_scheme_c}, leaf::Ptr{t8_element_t}, face::Cint)::Cint
+function t8_forest_leaf_face_orientation(forest, ltreeid, ts, leaf, face)
+    @ccall libt8.t8_forest_leaf_face_orientation(forest::t8_forest_t, ltreeid::t8_locidx_t, ts::Ptr{t8_eclass_scheme_c}, leaf::Ptr{t8_element_t}, face::Cint)::Cint
 end
 
 """
-    t8_forest_leaf_face_neighbors(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_eclass, forest_is_balanced)
+    t8_forest_leaf_face_neighbors(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_scheme, forest_is_balanced)
 
 Compute the leaf face neighbors of a forest.
 
@@ -11393,7 +15575,7 @@ Compute the leaf face neighbors of a forest.
 
     Important! This routine allocates memory which must be freed. Do it like this:
 
-if (num\\_neighbors > 0) { scheme->element\\_destroy (pneigh\\_eclass, num\\_neighbors, pneighbor\\_leaves); [`T8_FREE`](@ref) (pneighbor\\_leaves); [`T8_FREE`](@ref) (pelement\\_indices); [`T8_FREE`](@ref) (dual\\_faces); }
+if (num\\_neighbors > 0) { eclass\\_scheme->[`t8_element_destroy`](@ref) (num\\_neighbors, neighbors); [`T8_FREE`](@ref) (pneighbor\\_leaves); [`T8_FREE`](@ref) (pelement\\_indices); [`T8_FREE`](@ref) (dual\\_faces); }
 
 # Arguments
 * `forest`:\\[in\\] The forest. Must have a valid ghost layer.
@@ -11404,19 +15586,19 @@ if (num\\_neighbors > 0) { scheme->element\\_destroy (pneigh\\_eclass, num\\_nei
 * `dual_faces`:\\[out\\] On output the face id's of the neighboring elements' faces.
 * `num_neighbors`:\\[out\\] On output the number of neighbor leaves.
 * `pelement_indices`:\\[out\\] Unallocated on input. On output the element indices of the neighbor leaves are stored here. 0, 1, ... num\\_local\\_el - 1 for local leaves and num\\_local\\_el , ... , num\\_local\\_el + num\\_ghosts - 1 for ghosts.
-* `pneigh_eclass`:\\[out\\] On output the eclass of the neighbor elements.
+* `pneigh_scheme`:\\[out\\] On output the eclass scheme of the neighbor elements.
 * `forest_is_balanced`:\\[in\\] True if we know that *forest* is balanced, false otherwise.
 ### Prototype
 ```c
-void t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf, t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors, t8_locidx_t **pelement_indices, t8_eclass_t *pneigh_eclass, int forest_is_balanced);
+void t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf, t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors, t8_locidx_t **pelement_indices, t8_eclass_scheme_c **pneigh_scheme, int forest_is_balanced);
 ```
 """
-function t8_forest_leaf_face_neighbors(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_eclass, forest_is_balanced)
-    @ccall libt8.t8_forest_leaf_face_neighbors(forest::t8_forest_t, ltreeid::t8_locidx_t, leaf::Ptr{t8_element_t}, pneighbor_leaves::Ptr{Ptr{Ptr{t8_element_t}}}, face::Cint, dual_faces::Ptr{Ptr{Cint}}, num_neighbors::Ptr{Cint}, pelement_indices::Ptr{Ptr{t8_locidx_t}}, pneigh_eclass::Ptr{t8_eclass_t}, forest_is_balanced::Cint)::Cvoid
+function t8_forest_leaf_face_neighbors(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_scheme, forest_is_balanced)
+    @ccall libt8.t8_forest_leaf_face_neighbors(forest::t8_forest_t, ltreeid::t8_locidx_t, leaf::Ptr{t8_element_t}, pneighbor_leaves::Ptr{Ptr{Ptr{t8_element_t}}}, face::Cint, dual_faces::Ptr{Ptr{Cint}}, num_neighbors::Ptr{Cint}, pelement_indices::Ptr{Ptr{t8_locidx_t}}, pneigh_scheme::Ptr{Ptr{t8_eclass_scheme_c}}, forest_is_balanced::Cint)::Cvoid
 end
 
 """
-    t8_forest_leaf_face_neighbors_ext(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_eclass, forest_is_balanced, gneigh_tree, orientation)
+    t8_forest_leaf_face_neighbors_ext(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_scheme, forest_is_balanced, gneigh_tree, orientation)
 
 Like t8_forest_leaf_face_neighbors but also provides information about the global neighbors and the orientation.
 
@@ -11436,7 +15618,7 @@ Like t8_forest_leaf_face_neighbors but also provides information about the globa
 
     Important! This routine allocates memory which must be freed. Do it like this:
 
-if (num\\_neighbors > 0) { scheme->element\\_destroy (pneigh\\_eclass, num\\_neighbors, pneighbor\\_leaves); [`T8_FREE`](@ref) (pneighbor\\_leaves); [`T8_FREE`](@ref) (pelement\\_indices); [`T8_FREE`](@ref) (dual\\_faces); }
+if (num\\_neighbors > 0) { eclass\\_scheme->[`t8_element_destroy`](@ref) (num\\_neighbors, neighbors); [`T8_FREE`](@ref) (pneighbor\\_leaves); [`T8_FREE`](@ref) (pelement\\_indices); [`T8_FREE`](@ref) (dual\\_faces); }
 
 # Arguments
 * `forest`:\\[in\\] The forest. Must have a valid ghost layer.
@@ -11447,17 +15629,17 @@ if (num\\_neighbors > 0) { scheme->element\\_destroy (pneigh\\_eclass, num\\_nei
 * `dual_faces`:\\[out\\] On output the face id's of the neighboring elements' faces.
 * `num_neighbors`:\\[out\\] On output the number of neighbor leaves.
 * `pelement_indices`:\\[out\\] Unallocated on input. On output the element indices of the neighbor leaves are stored here. 0, 1, ... num\\_local\\_el - 1 for local leaves and num\\_local\\_el , ... , num\\_local\\_el + num\\_ghosts - 1 for ghosts.
-* `pneigh_eclass`:\\[out\\] On output the eclass of the neighbor elements.
+* `pneigh_scheme`:\\[out\\] On output the eclass scheme of the neighbor elements.
 * `forest_is_balanced`:\\[in\\] True if we know that *forest* is balanced, false otherwise.
 * `gneigh_tree`:\\[out\\] The global tree IDs of the neighbor trees.
-* `orientation`:\\[out\\] If not NULL on input, the face orientation is computed and stored here. Thus, if the face connection is an inter-tree connection the orientation of the tree-to-tree connection is stored. Otherwise, the value 0 is stored. All other parameters and behavior are identical to t8_forest_leaf_face_neighbors.
+* `orientation`:\\[out\\] If not NULL on input, the face orientation is computed and stored here.  Thus, if the face connection is an inter-tree connection the orientation of the tree-to-tree connection is stored.  Otherwise, the value 0 is stored. All other parameters and behavior are identical to `t8_forest_leaf_face_neighbors`.
 ### Prototype
 ```c
-void t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf, t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors, t8_locidx_t **pelement_indices, t8_eclass_t *pneigh_eclass, int forest_is_balanced, t8_gloidx_t *gneigh_tree, int *orientation);
+void t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf, t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors, t8_locidx_t **pelement_indices, t8_eclass_scheme_c **pneigh_scheme, int forest_is_balanced, t8_gloidx_t *gneigh_tree, int *orientation);
 ```
 """
-function t8_forest_leaf_face_neighbors_ext(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_eclass, forest_is_balanced, gneigh_tree, orientation)
-    @ccall libt8.t8_forest_leaf_face_neighbors_ext(forest::t8_forest_t, ltreeid::t8_locidx_t, leaf::Ptr{t8_element_t}, pneighbor_leaves::Ptr{Ptr{Ptr{t8_element_t}}}, face::Cint, dual_faces::Ptr{Ptr{Cint}}, num_neighbors::Ptr{Cint}, pelement_indices::Ptr{Ptr{t8_locidx_t}}, pneigh_eclass::Ptr{t8_eclass_t}, forest_is_balanced::Cint, gneigh_tree::Ptr{t8_gloidx_t}, orientation::Ptr{Cint})::Cvoid
+function t8_forest_leaf_face_neighbors_ext(forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors, pelement_indices, pneigh_scheme, forest_is_balanced, gneigh_tree, orientation)
+    @ccall libt8.t8_forest_leaf_face_neighbors_ext(forest::t8_forest_t, ltreeid::t8_locidx_t, leaf::Ptr{t8_element_t}, pneighbor_leaves::Ptr{Ptr{Ptr{t8_element_t}}}, face::Cint, dual_faces::Ptr{Ptr{Cint}}, num_neighbors::Ptr{Cint}, pelement_indices::Ptr{Ptr{t8_locidx_t}}, pneigh_scheme::Ptr{Ptr{t8_eclass_scheme_c}}, forest_is_balanced::Cint, gneigh_tree::Ptr{t8_gloidx_t}, orientation::Ptr{Cint})::Cvoid
 end
 
 """
@@ -11652,7 +15834,7 @@ function t8_forest_get_tree_vertices(forest, ltreeid)
 end
 
 """
-    t8_forest_tree_get_leaf_elements(forest, ltree_id)
+    t8_forest_tree_get_leaves(forest, ltree_id)
 
 Return the array of leaf elements of a local tree in a forest.
 
@@ -11663,11 +15845,11 @@ Return the array of leaf elements of a local tree in a forest.
 An array of [`t8_element_t`](@ref) * storing all leaf elements of this tree.
 ### Prototype
 ```c
-t8_element_array_t * t8_forest_tree_get_leaf_elements (const t8_forest_t forest, const t8_locidx_t ltree_id);
+t8_element_array_t * t8_forest_tree_get_leaves (const t8_forest_t forest, const t8_locidx_t ltree_id);
 ```
 """
-function t8_forest_tree_get_leaf_elements(forest, ltree_id)
-    @ccall libt8.t8_forest_tree_get_leaf_elements(forest::t8_forest_t, ltree_id::t8_locidx_t)::Ptr{t8_element_array_t}
+function t8_forest_tree_get_leaves(forest, ltree_id)
+    @ccall libt8.t8_forest_tree_get_leaves(forest::t8_forest_t, ltree_id::t8_locidx_t)::Ptr{t8_element_array_t}
 end
 
 """
@@ -11689,82 +15871,76 @@ function t8_forest_get_cmesh(forest)
 end
 
 """
-    t8_forest_get_leaf_element(forest, lelement_id, ltreeid)
+    t8_forest_get_element(forest, lelement_id, ltreeid)
 
-Return a leaf element of the forest.
-
-!!! note
-
-    This function performs a binary search. For constant access, use t8_forest_get_leaf_element_in_tree *forest* must be committed before calling this function.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `lelement_id`:\\[in\\] The local id of a leaf element in *forest*.
-* `ltreeid`:\\[out\\] If not NULL, on output the local tree id of the tree in which the leaf element lies in.
-# Returns
-A pointer to the leaf element. NULL if this element does not exist. Ghost elements are not considered as local.
-# See also
-[`t8_forest_ghost_get_leaf_element`](@ref) to access ghost leaf elements.
-
-### Prototype
-```c
-t8_element_t * t8_forest_get_leaf_element (t8_forest_t forest, t8_locidx_t lelement_id, t8_locidx_t *ltreeid);
-```
-"""
-function t8_forest_get_leaf_element(forest, lelement_id, ltreeid)
-    @ccall libt8.t8_forest_get_leaf_element(forest::t8_forest_t, lelement_id::t8_locidx_t, ltreeid::Ptr{t8_locidx_t})::Ptr{t8_element_t}
-end
-
-"""
-    t8_forest_get_leaf_element_in_tree(forest, ltreeid, leid_in_tree)
-
-Return a leaf element of a local tree in a forest.
+Return an element of the forest.
 
 !!! note
 
-    If the tree id is know, this function should be preferred over t8_forest_get_leaf_element. *forest* must be committed before calling this function.
+    This function performs a binary search. For constant access, use t8_forest_get_element_in_tree *forest* must be committed before calling this function.
 
 # Arguments
 * `forest`:\\[in\\] The forest.
-* `ltreeid`:\\[in\\] An id of a local tree in the forest. Ghost trees are not considered local.
-* `leid_in_tree`:\\[in\\] The index of a leaf element in the tree.
+* `lelement_id`:\\[in\\] The local id of an element in *forest*.
+* `ltreeid`:\\[out\\] If not NULL, on output the local tree id of the tree in which the element lies in.
 # Returns
-A pointer to the leaf element.
-# See also
-t8\\_forest\\_ghost\\_get\\_leaf\\_element\\_in\\_tree to access ghost leaf elements.
-
+A pointer to the element. NULL if this element does not exist.
 ### Prototype
 ```c
-const t8_element_t * t8_forest_get_leaf_element_in_tree (t8_forest_t forest, t8_locidx_t ltreeid, t8_locidx_t leid_in_tree);
+t8_element_t * t8_forest_get_element (t8_forest_t forest, t8_locidx_t lelement_id, t8_locidx_t *ltreeid);
 ```
 """
-function t8_forest_get_leaf_element_in_tree(forest, ltreeid, leid_in_tree)
-    @ccall libt8.t8_forest_get_leaf_element_in_tree(forest::t8_forest_t, ltreeid::t8_locidx_t, leid_in_tree::t8_locidx_t)::Ptr{t8_element_t}
+function t8_forest_get_element(forest, lelement_id, ltreeid)
+    @ccall libt8.t8_forest_get_element(forest::t8_forest_t, lelement_id::t8_locidx_t, ltreeid::Ptr{t8_locidx_t})::Ptr{t8_element_t}
 end
 
 """
-    t8_forest_get_tree_num_leaf_elements(forest, ltreeid)
+    t8_forest_get_element_in_tree(forest, ltreeid, leid_in_tree)
 
-Return the number of leaf elements of a tree.
+Return an element of a local tree in a forest.
+
+!!! note
+
+    If the tree id is know, this function should be preferred over t8_forest_get_element. *forest* must be committed before calling this function.
+
+# Arguments
+* `forest`:\\[in\\] The forest.
+* `ltreeid`:\\[in\\] An id of a local tree in the forest.
+* `leid_in_tree`:\\[in\\] The index of an element in the tree.
+# Returns
+A pointer to the element.
+### Prototype
+```c
+const t8_element_t * t8_forest_get_element_in_tree (t8_forest_t forest, t8_locidx_t ltreeid, t8_locidx_t leid_in_tree);
+```
+"""
+function t8_forest_get_element_in_tree(forest, ltreeid, leid_in_tree)
+    @ccall libt8.t8_forest_get_element_in_tree(forest::t8_forest_t, ltreeid::t8_locidx_t, leid_in_tree::t8_locidx_t)::Ptr{t8_element_t}
+end
+
+"""
+    t8_forest_get_tree_num_elements(forest, ltreeid)
+
+Return the number of elements of a tree.
 
 # Arguments
 * `forest`:\\[in\\] The forest.
 * `ltreeid`:\\[in\\] A local id of a tree.
 # Returns
-The number of leaf elements in the local tree *ltreeid*.
+The number of elements in the local tree *ltreeid*.
 ### Prototype
 ```c
-t8_locidx_t t8_forest_get_tree_num_leaf_elements (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_locidx_t t8_forest_get_tree_num_elements (t8_forest_t forest, t8_locidx_t ltreeid);
 ```
 """
-function t8_forest_get_tree_num_leaf_elements(forest, ltreeid)
-    @ccall libt8.t8_forest_get_tree_num_leaf_elements(forest::t8_forest_t, ltreeid::t8_locidx_t)::t8_locidx_t
+function t8_forest_get_tree_num_elements(forest, ltreeid)
+    @ccall libt8.t8_forest_get_tree_num_elements(forest::t8_forest_t, ltreeid::t8_locidx_t)::t8_locidx_t
 end
 
 """
     t8_forest_get_tree_element_offset(forest, ltreeid)
 
-Return the element offset of a local tree, that is the number of leaf elements in all trees with smaller local treeid.
+Return the element offset of a local tree, that is the number of elements in all trees with smaller local treeid.
 
 !!! note
 
@@ -11785,21 +15961,21 @@ function t8_forest_get_tree_element_offset(forest, ltreeid)
 end
 
 """
-    t8_forest_get_tree_leaf_element_count(tree)
+    t8_forest_get_tree_element_count(tree)
 
-Return the number of leaf elements of a tree.
+Return the number of elements of a tree.
 
 # Arguments
 * `tree`:\\[in\\] A tree in a forest.
 # Returns
-The number of leaf elements of that tree.
+The number of elements of that tree.
 ### Prototype
 ```c
-t8_locidx_t t8_forest_get_tree_leaf_element_count (t8_tree_t tree);
+t8_locidx_t t8_forest_get_tree_element_count (t8_tree_t tree);
 ```
 """
-function t8_forest_get_tree_leaf_element_count(tree)
-    @ccall libt8.t8_forest_get_tree_leaf_element_count(tree::t8_tree_t)::t8_locidx_t
+function t8_forest_get_tree_element_count(tree)
+    @ccall libt8.t8_forest_get_tree_element_count(tree::t8_tree_t)::t8_locidx_t
 end
 
 """
@@ -11822,21 +15998,21 @@ function t8_forest_get_tree_class(forest, ltreeid)
 end
 
 """
-    t8_forest_get_first_local_leaf_element_id(forest)
+    t8_forest_get_first_local_element_id(forest)
 
-Compute the global index of the first local leaf element of a forest. This function is collective.
+Compute the global index of the first local element of a forest. This function is collective.
 
 # Arguments
-* `forest`:\\[in\\] A committed forest, whose first leaf element's index is computed.
+* `forest`:\\[in\\] A committed forest, whose first element's index is computed.
 # Returns
-The global index of *forest*'s first local leaf element. Forest must be committed when calling this function. This function is collective and must be called on each process.
+The global index of *forest*'s first local element. Forest must be committed when calling this function. This function is collective and must be called on each process.
 ### Prototype
 ```c
-t8_gloidx_t t8_forest_get_first_local_leaf_element_id (t8_forest_t forest);
+t8_gloidx_t t8_forest_get_first_local_element_id (t8_forest_t forest);
 ```
 """
-function t8_forest_get_first_local_leaf_element_id(forest)
-    @ccall libt8.t8_forest_get_first_local_leaf_element_id(forest::t8_forest_t)::t8_gloidx_t
+function t8_forest_get_first_local_element_id(forest)
+    @ccall libt8.t8_forest_get_first_local_element_id(forest::t8_forest_t)::t8_gloidx_t
 end
 
 """
@@ -11845,7 +16021,7 @@ end
 Return the element scheme associated to a forest.
 
 # Arguments
-* `forest`:\\[in\\] A committed forest.
+* `forest.`:\\[in\\] A committed forest.
 # Returns
 The element scheme of the forest.
 # See also
@@ -11853,11 +16029,37 @@ The element scheme of the forest.
 
 ### Prototype
 ```c
-const t8_scheme_c * t8_forest_get_scheme (const t8_forest_t forest);
+t8_scheme_cxx_t * t8_forest_get_scheme (const t8_forest_t forest);
 ```
 """
 function t8_forest_get_scheme(forest)
-    @ccall libt8.t8_forest_get_scheme(forest::t8_forest_t)::Ptr{t8_scheme_c}
+    @ccall libt8.t8_forest_get_scheme(forest::t8_forest_t)::Ptr{t8_scheme_cxx_t}
+end
+
+"""
+    t8_forest_get_eclass_scheme(forest, eclass)
+
+Return the eclass scheme of a given element class associated to a forest.
+
+!!! note
+
+    The forest is not required to have trees of class *eclass*.
+
+# Arguments
+* `forest.`:\\[in\\] A committed forest.
+* `eclass.`:\\[in\\] An element class.
+# Returns
+The eclass scheme of *eclass* associated to forest.
+# See also
+[`t8_forest_set_scheme`](@ref)
+
+### Prototype
+```c
+t8_eclass_scheme_c * t8_forest_get_eclass_scheme (t8_forest_t forest, t8_eclass_t eclass);
+```
+"""
+function t8_forest_get_eclass_scheme(forest, eclass)
+    @ccall libt8.t8_forest_get_eclass_scheme(forest::t8_forest_t, eclass::t8_eclass_t)::Ptr{t8_eclass_scheme_c}
 end
 
 """
@@ -11866,10 +16068,10 @@ end
 Return the eclass of the tree in which a face neighbor of a given element lies.
 
 # Arguments
-* `forest`:\\[in\\] A committed forest.
-* `ltreeid`:\\[in\\] The local tree in which the element lies.
-* `elem`:\\[in\\] An element in the tree *ltreeid*.
-* `face`:\\[in\\] A face number of *elem*.
+* `forest.`:\\[in\\] A committed forest.
+* `ltreeid.`:\\[in\\] The local tree in which the element lies.
+* `elem.`:\\[in\\] An element in the tree *ltreeid*.
+* `face.`:\\[in\\] A face number of *elem*.
 # Returns
 The local tree id of the tree in which the face neighbor of *elem* across *face* lies.
 ### Prototype
@@ -11882,36 +16084,30 @@ function t8_forest_element_neighbor_eclass(forest, ltreeid, elem, face)
 end
 
 """
-    t8_forest_element_face_neighbor(forest, ltreeid, elem, neigh, neigh_eclass, face, neigh_face)
+    t8_forest_element_face_neighbor(forest, ltreeid, elem, neigh, neigh_scheme, face, neigh_face)
 
 Construct the face neighbor of an element, possibly across tree boundaries. Returns the global tree-id of the tree in which the neighbor element lies in.
 
 # Arguments
-* `forest`:\\[in\\] The forest.
-* `ltreeid`:\\[in\\] The local tree in which the element lies.
 * `elem`:\\[in\\] The element to be considered.
 * `neigh`:\\[in,out\\] On input an allocated element of the scheme of the face\\_neighbors eclass. On output, this element's data is filled with the data of the face neighbor. If the neighbor does not exist the data could be modified arbitrarily.
-* `neigh_eclass`:\\[in\\] The eclass of *neigh*.
+* `neigh_scheme`:\\[in\\] The eclass scheme of *neigh*.
 * `face`:\\[in\\] The number of the face along which the neighbor should be constructed.
 * `neigh_face`:\\[out\\] The number of the face viewed from perspective of *neigh*.
 # Returns
 The global tree-id of the tree in which *neigh* is in. -1 if there exists no neighbor across that face.
 ### Prototype
 ```c
-t8_gloidx_t t8_forest_element_face_neighbor (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *elem, t8_element_t *neigh, const t8_eclass_t neigh_eclass, int face, int *neigh_face);
+t8_gloidx_t t8_forest_element_face_neighbor (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *elem, t8_element_t *neigh, t8_eclass_scheme_c *neigh_scheme, int face, int *neigh_face);
 ```
 """
-function t8_forest_element_face_neighbor(forest, ltreeid, elem, neigh, neigh_eclass, face, neigh_face)
-    @ccall libt8.t8_forest_element_face_neighbor(forest::t8_forest_t, ltreeid::t8_locidx_t, elem::Ptr{t8_element_t}, neigh::Ptr{t8_element_t}, neigh_eclass::t8_eclass_t, face::Cint, neigh_face::Ptr{Cint})::t8_gloidx_t
+function t8_forest_element_face_neighbor(forest, ltreeid, elem, neigh, neigh_scheme, face, neigh_face)
+    @ccall libt8.t8_forest_element_face_neighbor(forest::t8_forest_t, ltreeid::t8_locidx_t, elem::Ptr{t8_element_t}, neigh::Ptr{t8_element_t}, neigh_scheme::Ptr{t8_eclass_scheme_c}, face::Cint, neigh_face::Ptr{Cint})::t8_gloidx_t
 end
 
 """
     t8_forest_iterate(forest)
 
-TODO: Can be removed since it is unused.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
 ### Prototype
 ```c
 void t8_forest_iterate (t8_forest_t forest);
@@ -11928,15 +16124,15 @@ Query whether a batch of points lies inside an element. For bilinearly interpola
 
 !!! note
 
-    For 2D quadrilateral elements this function is only an approximation. It is correct if the four vertices lie in the same plane, but it may produce only approximate results if the vertices do not lie in the same plane.
+    For 2D quadrilateral elements this function is only an approximation. It is correct if the four vertices lie in the same plane, but it may produce only approximate results if  the vertices do not lie in the same plane.
 
 # Arguments
 * `forest`:\\[in\\] The forest.
-* `ltreeid`:\\[in\\] The forest local id of the tree in which the element is.
+* `ltree_id`:\\[in\\] The forest local id of the tree in which the element is.
 * `element`:\\[in\\] The element.
 * `points`:\\[in\\] 3-dimensional coordinates of the points to check
 * `num_points`:\\[in\\] The number of points to check
-* `is_inside`:\\[in,out\\] An array of length *num_points*, filled with 0/1 on output. True (non-zero) if a *point* lies within an *element*, false otherwise. The return value is also true if the point lies on the element boundary. Thus, this function may return true for different leaf elements, if they are neighbors and the point lies on the common boundary.
+* `is_inside`:\\[in,out\\] An array of length *num_points*, filled with 0/1 on output. True (non-zero) if a *point*  lies within an *element*, false otherwise. The return value is also true if the point  lies on the element boundary. Thus, this function may return true for different leaf  elements, if they are neighbors and the point lies on the common boundary.
 * `tolerance`:\\[in\\] Tolerance that we allow the point to not exactly match the element. If this value is larger we detect more points. If it is zero we probably do not detect points even if they are inside due to rounding errors.
 ### Prototype
 ```c
@@ -11948,47 +16144,15 @@ function t8_forest_element_points_inside(forest, ltreeid, element, points, num_p
 end
 
 """
-    t8_forest_element_find_owner(forest, gtreeid, element, eclass)
-
-Find the owner process of a given element.
-
-!!! note
-
-    The element must not exist in the forest, but an ancestor of its first descendant has to. If the element's owner is not unique, the owner of the element's first descendant is returned.
-
-!!! note
-
-    *forest* must be committed before calling this function.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `gtreeid`:\\[in\\] The global id of the tree in which the element lies.
-* `element`:\\[in\\] The element to look for.
-* `eclass`:\\[in\\] The element class of the tree *gtreeid*.
-# Returns
-The mpirank of the process that owns *element*.
-# See also
-t8\\_forest\\_element\\_find\\_owner\\_ext, t8\\_forest\\_element\\_owners\\_bounds
-
-### Prototype
-```c
-int t8_forest_element_find_owner (t8_forest_t forest, t8_gloidx_t gtreeid, t8_element_t *element, t8_eclass_t eclass);
-```
-"""
-function t8_forest_element_find_owner(forest, gtreeid, element, eclass)
-    @ccall libt8.t8_forest_element_find_owner(forest::t8_forest_t, gtreeid::t8_gloidx_t, element::Ptr{t8_element_t}, eclass::t8_eclass_t)::Cint
-end
-
-"""
     t8_forest_new_uniform(cmesh, scheme, level, do_face_ghost, comm)
 
 ### Prototype
 ```c
-t8_forest_t t8_forest_new_uniform (t8_cmesh_t cmesh, const t8_scheme_c *scheme, const int level, const int do_face_ghost, sc_MPI_Comm comm);
+t8_forest_t t8_forest_new_uniform (t8_cmesh_t cmesh, t8_scheme_cxx_t *scheme, const int level, const int do_face_ghost, sc_MPI_Comm comm);
 ```
 """
 function t8_forest_new_uniform(cmesh, scheme, level, do_face_ghost, comm)
-    @ccall libt8.t8_forest_new_uniform(cmesh::t8_cmesh_t, scheme::Ptr{t8_scheme_c}, level::Cint, do_face_ghost::Cint, comm::MPI_Comm)::t8_forest_t
+    @ccall libt8.t8_forest_new_uniform(cmesh::t8_cmesh_t, scheme::Ptr{t8_scheme_cxx_t}, level::Cint, do_face_ghost::Cint, comm::MPI_Comm)::t8_forest_t
 end
 
 """
@@ -12003,7 +16167,8 @@ Build a adapted forest from another forest.
 # Arguments
 * `forest_from`:\\[in\\] The forest to refine
 * `adapt_fn`:\\[in\\] Adapt function to use
-* `recursive`:\\[in\\] If true adaptation is recursive
+* `replace_fn`:\\[in\\] Replace function to use
+* `recursive`:\\[in\\] If true adptation is recursive
 * `do_face_ghost`:\\[in\\] If true, a layer of ghost elements is created for the forest.
 * `user_data`:\\[in\\] If not NULL, the user data pointer of the forest is set to this value.
 # Returns
@@ -12169,27 +16334,20 @@ function t8_forest_element_face_normal(forest, ltreeid, element, face, normal)
     @ccall libt8.t8_forest_element_face_normal(forest::t8_forest_t, ltreeid::t8_locidx_t, element::Ptr{t8_element_t}, face::Cint, normal::Ptr{Cdouble})::Cvoid
 end
 
-"""We can reuse the reference counter type from libsc."""
-const t8_refcount_t = sc_refcount_t
-
 """
     t8_forest_ghost
-
-This struct stores various information about a forest's ghost elements and ghost trees.
 
 | Field                             | Note                                                                                                                                                                                                                                                                                                                                                      |
 | :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | rc                                | The reference counter.                                                                                                                                                                                                                                                                                                                                    |
-| num\\_ghosts\\_elements           | The count of non-local ghost leaf elements                                                                                                                                                                                                                                                                                                                |
-| num\\_remote\\_elements           | The count of local leaf elements that are ghost to another process.                                                                                                                                                                                                                                                                                       |
+| num\\_ghosts\\_elements           | The count of non-local ghost elements                                                                                                                                                                                                                                                                                                                     |
+| num\\_remote\\_elements           | The count of local elements that are ghost to another process.                                                                                                                                                                                                                                                                                            |
 | ghost\\_type                      | Describes which neighbors are considered ghosts.                                                                                                                                                                                                                                                                                                          |
 | ghost\\_trees                     | ghost tree data: global\\_id. eclass. elements. In linear id order                                                                                                                                                                                                                                                                                        |
 | global\\_tree\\_to\\_ghost\\_tree | Indexes into ghost\\_trees. Given a global tree id I give the index i such that the tree is in ghost\\_trees[i]                                                                                                                                                                                                                                           |
 | process\\_offsets                 | Given a process, return the first ghost tree and within it the first element of that process.                                                                                                                                                                                                                                                             |
 | remote\\_ghosts                   | array of local trees that have ghost elements for another process. for each tree an array of [`t8_element_t`](@ref) * of the local ghost elements. Also an array of [`t8_locidx_t`](@ref) of the local indices of these elements within the tree. It is a hash table, hashed with the rank of a remote process. Sorted within each process by linear id.  |
 | remote\\_processes                | The ranks of the processes for which local elements are ghost. Array of int's.                                                                                                                                                                                                                                                                            |
-| glo\\_tree\\_mempool              | The global tree memory pool.                                                                                                                                                                                                                                                                                                                              |
-| proc\\_offset\\_mempool           | The process offset memory pool.                                                                                                                                                                                                                                                                                                                           |
 """
 struct t8_forest_ghost
     rc::t8_refcount_t
@@ -12210,14 +16368,6 @@ const t8_forest_ghost_t = Ptr{t8_forest_ghost}
 """
     t8_forest_ghost_init(pghost, ghost_type)
 
-Initialize a ghost type of a forest.
-
-# Arguments
-* `pghost`:\\[out\\] Pointer to the forest's ghost.
-* `ghost_type`:\\[in\\] The type of the ghost elements,
-# See also
-[`t8_ghost_type_t`](@ref).
-
 ### Prototype
 ```c
 void t8_forest_ghost_init (t8_forest_ghost_t *pghost, t8_ghost_type_t ghost_type);
@@ -12230,12 +16380,6 @@ end
 """
     t8_forest_ghost_num_trees(forest)
 
-Return the number of trees in a ghost.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-# Returns
-The number of trees in the forest's ghost (or 0 if ghost structure does not exist).
 ### Prototype
 ```c
 t8_locidx_t t8_forest_ghost_num_trees (const t8_forest_t forest);
@@ -12258,7 +16402,7 @@ Return the element offset of a ghost tree.
 * `forest`:\\[in\\] The forest with constructed ghost layer.
 * `lghost_tree`:\\[in\\] A local ghost id of a ghost tree.
 # Returns
-The element offset of this ghost tree within the set of local ghost elements.
+The element offset of this ghost tree.
 ### Prototype
 ```c
 t8_locidx_t t8_forest_ghost_get_tree_element_offset (t8_forest_t forest, t8_locidx_t lghost_tree);
@@ -12269,41 +16413,34 @@ function t8_forest_ghost_get_tree_element_offset(forest, lghost_tree)
 end
 
 """
-    t8_forest_ghost_tree_num_leaf_elements(forest, lghost_tree)
+    t8_forest_ghost_tree_num_elements(forest, lghost_tree)
 
-Given an index in the ghost\\_tree array, return this tree's number of leaf elements
-
-# Arguments
-* `forest`:\\[in\\] The *forest*. Ghost layer must exist.
-* `lghost_tree`:\\[in\\] The ghost tree id of a ghost tree.
-# Returns
-The number of ghost leaf elements of the tree. *forest* must be committed before calling this function.
 ### Prototype
 ```c
-t8_locidx_t t8_forest_ghost_tree_num_leaf_elements (t8_forest_t forest, t8_locidx_t lghost_tree);
+t8_locidx_t t8_forest_ghost_tree_num_elements (t8_forest_t forest, t8_locidx_t lghost_tree);
 ```
 """
-function t8_forest_ghost_tree_num_leaf_elements(forest, lghost_tree)
-    @ccall libt8.t8_forest_ghost_tree_num_leaf_elements(forest::t8_forest_t, lghost_tree::t8_locidx_t)::t8_locidx_t
+function t8_forest_ghost_tree_num_elements(forest, lghost_tree)
+    @ccall libt8.t8_forest_ghost_tree_num_elements(forest::t8_forest_t, lghost_tree::t8_locidx_t)::t8_locidx_t
 end
 
 """
-    t8_forest_ghost_get_tree_leaf_elements(forest, lghost_tree)
+    t8_forest_ghost_get_tree_elements(forest, lghost_tree)
 
-Get a pointer to the ghost leaf element array of a ghost tree.
+Get a pointer to the ghost element array of a ghost tree.
 
 # Arguments
 * `forest`:\\[in\\] The forest. Ghost layer must exist.
 * `lghost_tree`:\\[in\\] The ghost tree id of a ghost tree.
 # Returns
-A pointer to the array of ghost leaf elements of the tree. *forest* must be committed before calling this function.
+A pointer to the array of ghost elements of the tree. *forest* must be committed before calling this function.
 ### Prototype
 ```c
-t8_element_array_t * t8_forest_ghost_get_tree_leaf_elements (const t8_forest_t forest, const t8_locidx_t lghost_tree);
+t8_element_array_t * t8_forest_ghost_get_tree_elements (const t8_forest_t forest, const t8_locidx_t lghost_tree);
 ```
 """
-function t8_forest_ghost_get_tree_leaf_elements(forest, lghost_tree)
-    @ccall libt8.t8_forest_ghost_get_tree_leaf_elements(forest::t8_forest_t, lghost_tree::t8_locidx_t)::Ptr{t8_element_array_t}
+function t8_forest_ghost_get_tree_elements(forest, lghost_tree)
+    @ccall libt8.t8_forest_ghost_get_tree_elements(forest::t8_forest_t, lghost_tree::t8_locidx_t)::Ptr{t8_element_array_t}
 end
 
 """
@@ -12331,13 +16468,6 @@ end
 """
     t8_forest_ghost_get_tree_class(forest, lghost_tree)
 
-Given an index in the ghost\\_tree array, return this tree's element class.
-
-# Arguments
-* `forest`:\\[in\\] A committed forest.
-* `lghost_tree`:\\[in\\] The tree's local index in the ghost\\_tree array.
-# Returns
-The element class of the given tree.
 ### Prototype
 ```c
 t8_eclass_t t8_forest_ghost_get_tree_class (const t8_forest_t forest, const t8_locidx_t lghost_tree);
@@ -12354,7 +16484,7 @@ Given a local ghost tree compute the global tree id of it.
 
 # Arguments
 * `forest`:\\[in\\] The forest. Ghost layer must exist.
-* `lghost_tree`:\\[in\\] The ghost tree id of a ghost tree. (0 <= *lghost_tree* < num\\_ghost\\_trees)
+* `lghost_tree`:\\[in\\] The ghost tree id of a ghost tree.
 # Returns
 The global id of the local ghost tree *lghost_tree*. *forest* must be committed before calling this function.
 # See also
@@ -12370,47 +16500,15 @@ function t8_forest_ghost_get_global_treeid(forest, lghost_tree)
 end
 
 """
-    t8_forest_ghost_get_leaf_element(forest, lghost_tree, lelement)
+    t8_forest_ghost_get_element(forest, lghost_tree, lelement)
 
-Given an index into the ghost\\_trees array and for that tree an element index, return the corresponding element.
-
-# Arguments
-* `forest`:\\[in\\] The *forest*. Ghost layer must exist.
-* `lghost_tree`:\\[in\\] The ghost tree id of a ghost tree.
-* `lelement`:\\[in\\] The local id of the ghost leaf element considered.
-# Returns
-A pointer to the ghost leaf element. *forest* must be committed before calling this function.
 ### Prototype
 ```c
-t8_element_t * t8_forest_ghost_get_leaf_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_locidx_t lelement);
+t8_element_t * t8_forest_ghost_get_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_locidx_t lelement);
 ```
 """
-function t8_forest_ghost_get_leaf_element(forest, lghost_tree, lelement)
-    @ccall libt8.t8_forest_ghost_get_leaf_element(forest::t8_forest_t, lghost_tree::t8_locidx_t, lelement::t8_locidx_t)::Ptr{t8_element_t}
-end
-
-"""
-    t8_forest_element_is_ghost(forest, element, lghost_tree)
-
-Query whether a given element is a ghost of a certrain tree in a forest.
-
-!!! note
-
-    *forest* must be committed before calling this function.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `element`:\\[in\\] An element of a ghost tree in *forest*.
-* `lghost_tree`:\\[in\\] A local ghost tree id of *forest*. (0 <= *lghost_tree* < num\\_ghost\\_trees)
-# Returns
-True (non-zero) if and only if *element* is a ghost in *lghost_tree* of *forest*.
-### Prototype
-```c
-int t8_forest_element_is_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t lghost_tree);
-```
-"""
-function t8_forest_element_is_ghost(forest, element, lghost_tree)
-    @ccall libt8.t8_forest_element_is_ghost(forest::t8_forest_t, element::Ptr{t8_element_t}, lghost_tree::t8_locidx_t)::Cint
+function t8_forest_ghost_get_element(forest, lghost_tree, lelement)
+    @ccall libt8.t8_forest_ghost_get_element(forest::t8_forest_t, lghost_tree::t8_locidx_t, lelement::t8_locidx_t)::Ptr{t8_element_t}
 end
 
 """
@@ -12505,7 +16603,7 @@ end
 """
     t8_forest_ghost_destroy(pghost)
 
-Verify that a ghost structure has only one reference left and destroy it. This function is preferred over t8_forest_ghost_unref when it is known that the last reference is to be deleted.
+Verify that a ghost structure has only one reference left and destroy it. This function is preferred over t8_ghost_unref when it is known that the last reference is to be deleted.
 
 # Arguments
 * `pghost`:\\[in,out\\] This ghost structure must have a reference count of one. It can be in any state (committed or not). Then it effectively calls t8_forest_ghost_unref.
@@ -12560,8 +16658,6 @@ end
 """
     t8_forest_ghost_create_topdown(forest)
 
-Experimental version of t8_forest_ghost_create using the ghost\\_v3 algorithm
-
 ### Prototype
 ```c
 void t8_forest_ghost_create_topdown (t8_forest_t forest);
@@ -12581,37 +16677,6 @@ void t8_forest_save (t8_forest_t forest);
 """
 function t8_forest_save(forest)
     @ccall libt8.t8_forest_save(forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_vtk_data_type_t
-
-TODO: Add support for integer data type.
-
-| Enumerator        | Note                          |
-| :---------------- | :---------------------------- |
-| T8\\_VTK\\_SCALAR | One double value per element  |
-| T8\\_VTK\\_VECTOR | 3 double values per element   |
-"""
-@cenum t8_vtk_data_type_t::UInt32 begin
-    T8_VTK_SCALAR = 0
-    T8_VTK_VECTOR = 1
-end
-
-"""
-    t8_vtk_data_field_t
-
-A data field for VTK output. This struct is used to store data that is written to the VTK files. It contains the type of the data, a description, and the actual data array.
-
-| Field       | Note                                       |
-| :---------- | :----------------------------------------- |
-| type        | Describes of which type the data array is  |
-| description | String that describes the data.            |
-"""
-struct t8_vtk_data_field_t
-    type::t8_vtk_data_type_t
-    description::NTuple{8192, Cchar}
-    data::Ptr{Cdouble}
 end
 
 """
@@ -12638,22 +16703,7 @@ function t8_forest_write_vtk(forest, fileprefix)
     @ccall libt8.t8_forest_write_vtk(forest::t8_forest_t, fileprefix::Cstring)::Cint
 end
 
-# typedef int ( * t8_forest_iterate_face_fn ) ( const t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int face , void * user_data , const t8_locidx_t tree_leaf_index )
-"""
-Callback function used in
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `ltreeid`:\\[in\\] Local index of the tree containing the *element*.
-* `element`:\\[in\\] The considered element.
-* `face`:\\[in\\] The integer index of the considered face of *element*.
-* `user_data`:\\[in\\] Some user-defined data, as void pointer.
-* `tree_leaf_index`:\\[in\\] Tree-local index the first leaf.
-# Returns
-Nonzero if the element may touch the face and the top-down search shall be continued, zero otherwise.
-# See also
-[`t8_forest_iterate_faces`](@ref).
-"""
+# typedef int ( * t8_forest_iterate_face_fn ) ( t8_forest_t forest , t8_locidx_t ltreeid , const t8_element_t * element , int face , void * user_data , t8_locidx_t tree_leaf_index )
 const t8_forest_iterate_face_fn = Ptr{Cvoid}
 
 # typedef int ( * t8_forest_search_fn ) ( t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int is_leaf , const t8_element_array_t * leaf_elements , const t8_locidx_t tree_leaf_index )
@@ -12684,56 +16734,18 @@ A call-back function used by t8_forest_search for queries. Is called on an eleme
 * `leaf_elements`:\\[in\\] the leaf elements in *forest* that are descendants of *element* (or the element  itself if *is_leaf* is true)
 * `tree_leaf_index`:\\[in\\] the local index of the first leaf in *leaf_elements*
 * `queries`:\\[in\\] An array of queries that are checked by the function
-* `query_indices`:\\[in\\] An array of size\\_t entries, where each entry is an index of a query in *queries*.
+* `query_indices`:\\[in\\] An array of size\\_t entries, where each entry is an index of a query in  queries.
 * `query_matches`:\\[in,out\\] An array of length *num_active_queries*.  If the element is not a leave must be set to true or false at the i-th index for  each query, specifying whether the element 'matches' the query of the i-th query  index or not. When the element is a leaf we can return before all entries are set.
 * `num_active_queries`:\\[in\\] The number of currently active queries (equals the number of entries of  *query_matches* and entries of *query_indices*).
 """
 const t8_forest_query_fn = Ptr{Cvoid}
 
-# typedef int ( * t8_forest_partition_search_fn ) ( const t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int pfirst , const int plast )
-"""
-A call-back function used by t8_forest_search_partition describing a search-criterion. Is called on an element and the search criterion should be checked on that element. Return true if the search criterion is met, false otherwise.
-
-# Arguments
-* `forest`:\\[in\\] the forest
-* `ltreeid`:\\[in\\] the local tree id of the current tree in the cmesh. Since the cmesh has to be replicated, it coincides with the global tree id.
-* `element`:\\[in\\] the element for which the search criterion is checked
-* `pfirst`:\\[in\\] the first processor that owns part of *element*. Guaranteed to be non-empty.
-* `plast`:\\[in\\] the last processor that owns part of *element*. Guaranteed to be non-empty.
-# Returns
-non-zero if the search criterion is met, zero otherwise.
-"""
-const t8_forest_partition_search_fn = Ptr{Cvoid}
-
-# typedef void ( * t8_forest_partition_query_fn ) ( const t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int pfirst , const int plast , void * queries , sc_array_t * query_indices , int * query_matches , const size_t num_active_queries )
-"""
-A call-back function used by t8_forest_search_partition for queries. Is called on an element and all queries are checked on that element. All positive queries are passed further down to the children of the element. The results of the check are stored in *query_matches*.
-
-# Arguments
-* `forest`:\\[in\\] the forest
-* `ltreeid`:\\[in\\] the local tree id of the current tree in the cmesh. Since the cmesh has to be replicated, it coincides with the global tree id.
-* `element`:\\[in\\] the element for which the query is executed
-* `pfirst`:\\[in\\] the first processor that owns part of *element*. Guaranteed to be non-empty.
-* `plast`:\\[in\\] the last processor that owns part of *element*. Guaranteed to be non-empty. if this is equal to *pfirst*, then the recursion will stop for *element*'s branch after this function returns.
-* `queries`:\\[in\\] an array of queries that are checked by the function
-* `query_indices`:\\[in\\] an array of size\\_t entries, where each entry is an index of a query in *queries*.
-* `query_matches`:\\[in,out\\] an array of length *num_active_queries*. If the element is not a leaf must be set to true or false at the i-th index for each query, specifying whether the element 'matches' the query of the i-th query index or not. When the element is a leaf we can return before all entries are set.
-* `num_active_queries`:\\[in\\] The number of currently active queries (equals the number of entries of *query_matches* and entries of *query_indices*).
-"""
-const t8_forest_partition_query_fn = Ptr{Cvoid}
-
 """
     t8_forest_split_array(element, leaf_elements, offsets)
 
-Split an array of elements according to the children of a given element E. In other words for each child C of E, find the index i, j, such that all descendants of C are elements[i], ..., elements[j-1].
-
-# Arguments
-* `element`:\\[in\\] An element.
-* `leaf_elements`:\\[in\\] An array of leaf elements of *element*. Thus, all elements must be descendants. Sorted by linear index.
-* `offsets`:\\[in,out\\] On input an allocated array of *num_children_of_E* + 1 entries.  On output entry i indicates the position in *leaf_elements* where the descandents of the i-th child of E start.
 ### Prototype
 ```c
-void t8_forest_split_array (const t8_element_t *element, const t8_element_array_t *leaf_elements, size_t *offsets);
+void t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_elements, size_t *offsets);
 ```
 """
 function t8_forest_split_array(element, leaf_elements, offsets)
@@ -12743,20 +16755,9 @@ end
 """
     t8_forest_iterate_faces(forest, ltreeid, element, face, leaf_elements, user_data, tree_lindex_of_first_leaf, callback)
 
-Iterate over all leaves of an element that touch a given face of the element. Callback is called in each recursive step with element as input. leaf\\_index is only not negative if element is a leaf, in which case it indicates the index of the leaf in the leaves of the tree. If it is negative, it is - (index + 1) Top-down iteration and callback is called on each intermediate level. If it returns false, the current element is not traversed further
-
-# Arguments
-* `forest`:\\[in\\] A committed forest.
-* `ltreeid`:\\[in\\] Local index of the tree containing the *element*.
-* `element`:\\[in\\] The considered element.
-* `face`:\\[in\\] The integer index of the considered face of *element*.
-* `leaf_elements`:\\[in\\] The array of leaf elements that are descendants of *element*. Sorted by linear index.
-* `user_data`:\\[in\\] The user data passed to the *callback* function.
-* `tree_lindex_of_first_leaf`:\\[in\\] Tree-local index of the first leaf.
-* `callback`:\\[in\\] The callback function.
 ### Prototype
 ```c
-void t8_forest_iterate_faces (const t8_forest_t forest, const t8_locidx_t ltreeid, const t8_element_t *element, const int face, const t8_element_array_t *leaf_elements, void *user_data, const t8_locidx_t tree_lindex_of_first_leaf, const t8_forest_iterate_face_fn callback);
+void t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, int face, t8_element_array_t *leaf_elements, void *user_data, t8_locidx_t tree_lindex_of_first_leaf, t8_forest_iterate_face_fn callback);
 ```
 """
 function t8_forest_iterate_faces(forest, ltreeid, element, face, leaf_elements, user_data, tree_lindex_of_first_leaf, callback)
@@ -12766,13 +16767,6 @@ end
 """
     t8_forest_search(forest, search_fn, query_fn, queries)
 
-Perform a top-down search of the forest, executing a callback on each intermediate element. The search will enter each tree at least once. If the callback returns false for an element, its descendants are not further searched. To pass user data to the search\\_fn function use t8_forest_set_user_data.
-
-# Arguments
-* `forest`:\\[in\\] The forest.
-* `search_fn`:\\[in\\] The callback function describing the search criterion.
-* `query_fn`:\\[in\\] The query function.
-* `queries`:\\[in\\] The array of queries.
 ### Prototype
 ```c
 void t8_forest_search (t8_forest_t forest, t8_forest_search_fn search_fn, t8_forest_query_fn query_fn, sc_array_t *queries);
@@ -12805,31 +16799,8 @@ function t8_forest_iterate_replace(forest_new, forest_old, replace_fn)
 end
 
 """
-    t8_forest_search_partition(forest, search_fn, query_fn, queries)
-
-Perform a top-down search of the global partition, executing a callback on each intermediate element. The search will enter each tree at least once. The recursion will only go down branches that are split between multiple processors. This is not a collective function. It does not communicate. The function expects the coarse mesh to be replicated. If the callback returns false for an element, its descendants are not further searched. To pass user data to **search_fn** function use t8_forest_set_user_data
-
-# Arguments
-* `forest`:\\[in\\] the forest to be searched
-* `search_fn`:\\[in\\] a search callback function called on elements
-* `query_fn`:\\[in\\] a query callback function called for all active queries of an element
-* `queries`:\\[in,out\\] an array of queries that are checked by the function
-### Prototype
-```c
-void t8_forest_search_partition (const t8_forest_t forest, t8_forest_partition_search_fn search_fn, t8_forest_partition_query_fn query_fn, sc_array_t *queries);
-```
-"""
-function t8_forest_search_partition(forest, search_fn, query_fn, queries)
-    @ccall libt8.t8_forest_search_partition(forest::t8_forest_t, search_fn::t8_forest_partition_search_fn, query_fn::t8_forest_partition_query_fn, queries::Ptr{sc_array_t})::Cvoid
-end
-
-"""
     t8_forest_partition(forest)
 
-Populate a forest with the partitioned elements of forest->set\\_from.
-
-# Arguments
-* `forest`:\\[in,out\\] The forest.
 ### Prototype
 ```c
 void t8_forest_partition (t8_forest_t forest);
@@ -12837,46 +16808,6 @@ void t8_forest_partition (t8_forest_t forest);
 """
 function t8_forest_partition(forest)
     @ccall libt8.t8_forest_partition(forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_new_gather(forest_from, gather_rank)
-
-Create a new forest that gathers a given forest on one process.
-
-This functionality is mostly required for comparison purposes and sanity checks within the testing framework.
-
-# Arguments
-* `forest_from`:\\[in\\] the forest that should be gathered on one rank
-* `gather_rank`:\\[in\\] the rank of the process the forest will be gathered on
-# Returns
-The gathered forest: The same as *forest_from*, but all elements are on rank *gather_rank*.
-### Prototype
-```c
-t8_forest_t t8_forest_new_gather (const t8_forest_t forest_from, const int gather_rank);
-```
-"""
-function t8_forest_new_gather(forest_from, gather_rank)
-    @ccall libt8.t8_forest_new_gather(forest_from::t8_forest_t, gather_rank::Cint)::t8_forest_t
-end
-
-"""
-    t8_forest_set_partition_offset(forest, first_global_element)
-
-Manually set the partition offset of the current process.
-
-If set, the next partitioning of the forest will use the manually defined element offsets.
-
-# Arguments
-* `forest`:\\[in,out\\] the considered forest
-* `first_global_element`:\\[in\\] the global ID that will become the first local element
-### Prototype
-```c
-void t8_forest_set_partition_offset (t8_forest_t forest, const t8_gloidx_t first_global_element);
-```
-"""
-function t8_forest_set_partition_offset(forest, first_global_element)
-    @ccall libt8.t8_forest_set_partition_offset(forest::t8_forest_t, first_global_element::t8_gloidx_t)::Cvoid
 end
 
 """
@@ -12956,7 +16887,7 @@ Re-Partition an array accordingly to a partitioned forest.
     *data_in* has to be of size equal to the number of local elements of *forest_from* *data_out* has to be already allocated and has to be of size equal to the number of local elements of *forest_to*.
 
 # Arguments
-* `forest_from`:\\[in\\] The forest before the partitioning step.
+* `forest_form`:\\[in\\] The forest before the partitioning step.
 * `forest_to`:\\[in\\] The partitioned forest of *forest_from*.
 * `data_in`:\\[in\\] A pointer to an [`sc_array_t`](@ref) holding data (one value per element) accordingly to *forest_from*.
 * `data_out`:\\[in,out\\] A pointer to an already allocated [`sc_array_t`](@ref) capable of holding data accordingly to *forest_to*.
@@ -12987,24 +16918,6 @@ void t8_forest_partition_test_boundary_element (const t8_forest_t forest);
 """
 function t8_forest_partition_test_boundary_element(forest)
     @ccall libt8.t8_forest_partition_test_boundary_element(forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_pfc_correction_offsets(forest)
-
-Correct the partitioning if element families are split across process boundaries.
-
-The default partitioning distributes the elements into equally-sized partitions. For coarsening, however, all elements of a family have to be on the same process in order to be coarsened into their parent element. This function corrects the partitioning such that no families are split across process boundaries. The price to be paid is a slight deviation from the optimal balance of elements among processors.
-
-# Arguments
-* `forest`:\\[in,out\\] the forest. On input, it has been partitioned into equally-sized element partitions. On output, the partitioning has been adjusted such that no element families are split across the process boundaries.
-### Prototype
-```c
-void t8_forest_pfc_correction_offsets (t8_forest_t forest);
-```
-"""
-function t8_forest_pfc_correction_offsets(forest)
-    @ccall libt8.t8_forest_pfc_correction_offsets(forest::t8_forest_t)::Cvoid
 end
 
 """
@@ -13176,65 +17089,24 @@ function t8_forest_profile_get_ghostexchange_waittime(forest)
 end
 
 """
-    t8_forest_profile_get_cmesh_offsets_runtime(forest)
-
-### Prototype
-```c
-double t8_forest_profile_get_cmesh_offsets_runtime (t8_forest_t forest);
-```
-"""
-function t8_forest_profile_get_cmesh_offsets_runtime(forest)
-    @ccall libt8.t8_forest_profile_get_cmesh_offsets_runtime(forest::t8_forest_t)::Cdouble
-end
-
-"""
-    t8_forest_profile_get_forest_offsets_runtime(forest)
-
-### Prototype
-```c
-double t8_forest_profile_get_forest_offsets_runtime (t8_forest_t forest);
-```
-"""
-function t8_forest_profile_get_forest_offsets_runtime(forest)
-    @ccall libt8.t8_forest_profile_get_forest_offsets_runtime(forest::t8_forest_t)::Cdouble
-end
-
-"""
-    t8_forest_profile_get_first_descendant_runtime(forest)
-
-### Prototype
-```c
-double t8_forest_profile_get_first_descendant_runtime (t8_forest_t forest);
-```
-"""
-function t8_forest_profile_get_first_descendant_runtime(forest)
-    @ccall libt8.t8_forest_profile_get_first_descendant_runtime(forest::t8_forest_t)::Cdouble
-end
-
-"""
     t8_profile
 
-This struct holds profiling information, such as timings or statistics about communication.
-
-| Field                          | Note                                                                                                           |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| partition\\_elements\\_shipped | The number of elements this process has sent to other in the last partition call.                              |
-| partition\\_elements\\_recv    | The number of elements this process has received from other in the last partition call.                        |
-| partition\\_bytes\\_sent       | The total number of bytes sent to other processes in the last partition call.                                  |
-| partition\\_procs\\_sent       | The number of different processes this process has send local elements to in the last partition call.          |
-| ghosts\\_shipped               | The number of ghost elements this process has sent to other processes.                                         |
-| ghosts\\_received              | The number of ghost elements this process has received from other processes.                                   |
-| ghosts\\_remotes               | The number of processes this process have sent ghost elements to (and received from).                          |
-| balance\\_rounds               | The number of iterations during balance.                                                                       |
-| adapt\\_runtime                | The runtime of the last call to [`t8_forest_adapt`](@ref) (not counting adaptation in t8\\_forest\\_balance).  |
-| partition\\_runtime            | The runtime of the last call to *t8_cmesh_partition* (not count in partition in t8\\_forest\\_balance).        |
-| ghost\\_runtime                | The runtime of the last call to [`t8_forest_ghost_create`](@ref).                                              |
-| ghost\\_waittime               | Amount of synchronisation time in ghost.                                                                       |
-| balance\\_runtime              | The runtime of the last call to *t8_forest_balance*.                                                           |
-| commit\\_runtime               | The runtime of the last call to [`t8_cmesh_commit`](@ref).                                                     |
-| cmesh\\_offsets\\_runtime      | The runtime of the last call to [`t8_forest_partition_create_tree_offsets`](@ref).                             |
-| forest\\_offsets\\_runtime     | The runtime of the last call to [`t8_forest_partition_create_offsets`](@ref).                                  |
-| first\\_descendant\\_runtime   | The runtime of the last call to [`t8_forest_partition_create_first_desc`](@ref).                               |
+| Field                          | Note                                                                                                                   |
+| :----------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| partition\\_elements\\_shipped | The number of elements this process has sent to other in the last partition call.                                      |
+| partition\\_elements\\_recv    | The number of elements this process has received from other in the last partition call.                                |
+| partition\\_bytes\\_sent       | The total number of bytes sent to other processes in the last partition call.                                          |
+| partition\\_procs\\_sent       | The number of different processes this process has send local elements to in the last partition call.                  |
+| ghosts\\_shipped               | The number of ghost elements this process has sent to other processes.                                                 |
+| ghosts\\_received              | The number of ghost elements this process has received from other processes.                                           |
+| ghosts\\_remotes               | The number of processes this process have sent ghost elements to (and received from).                                  |
+| balance\\_rounds               | The number of iterations during balance.                                                                               |
+| adapt\\_runtime                | The runtime of the last call to [`t8_forest_adapt`](@ref) (not counting adaptation in [`t8_forest_balance`](@ref)).    |
+| partition\\_runtime            | The runtime of the last call to [`t8_cmesh_partition`](@ref) (not count in partition in [`t8_forest_balance`](@ref)).  |
+| ghost\\_runtime                | The runtime of the last call to [`t8_forest_ghost_create`](@ref).                                                      |
+| ghost\\_waittime               | Amount of synchronisation time in ghost.                                                                               |
+| balance\\_runtime              | The runtime of the last call to [`t8_forest_balance`](@ref).                                                           |
+| commit\\_runtime               | The runtime of the last call to [`t8_cmesh_commit`](@ref).                                                             |
 """
 struct t8_profile
     partition_elements_shipped::t8_locidx_t
@@ -13251,12 +17123,8 @@ struct t8_profile
     ghost_waittime::Cdouble
     balance_runtime::Cdouble
     commit_runtime::Cdouble
-    cmesh_offsets_runtime::Cdouble
-    forest_offsets_runtime::Cdouble
-    first_descendant_runtime::Cdouble
 end
 
-"""This struct holds profiling information, such as timings or statistics about communication."""
 const t8_profile_t = t8_profile
 
 """If a forest is to be derived from another forest, there are different possibilities how the original forest is modified. Currently we support: Copying, adapting, partitioning, and balancing a forest. The latter 3 can be combined, in which case the order is 1. Adapt, 2. Partition, 3. Balance. We store the methods in an int8\\_t and use these defines to distinguish between them."""
@@ -13268,10 +17136,8 @@ const t8_forest_struct_t = t8_forest
 """The t8 tree datatype"""
 const t8_tree_struct_t = t8_tree
 
-"""This struct holds profiling information, such as timings or statistics about communication."""
 const t8_profile_struct_t = t8_profile
 
-"""This struct stores various information about a forest's ghost elements and ghost trees."""
 const t8_forest_ghost_struct_t = t8_forest_ghost
 
 """
@@ -13288,7 +17154,6 @@ This enumeration contains all possible geometries.
 | T8\\_GEOMETRY\\_TYPE\\_ANALYTIC                | The analytic geometry uses a user-defined analytic function to map into the physical domain.     |
 | T8\\_GEOMETRY\\_TYPE\\_CAD                     | The opencascade geometry uses CAD shapes to map trees exactly to the underlying CAD model.       |
 | T8\\_GEOMETRY\\_TYPE\\_COUNT                   | This is no geometry type but can be used as the number of geometry types.                        |
-| T8\\_GEOMETRY\\_TYPE\\_INVALID                 | This is no geometry type but is used as error type to describe invalid geometries                |
 | T8\\_GEOMETRY\\_TYPE\\_UNDEFINED               | This is no geometry type but is used for every geometry, where no type is defined                |
 """
 @cenum t8_geometry_type::UInt32 begin
@@ -13299,17 +17164,11 @@ This enumeration contains all possible geometries.
     T8_GEOMETRY_TYPE_ANALYTIC = 4
     T8_GEOMETRY_TYPE_CAD = 5
     T8_GEOMETRY_TYPE_COUNT = 6
-    T8_GEOMETRY_TYPE_INVALID = 7
-    T8_GEOMETRY_TYPE_UNDEFINED = 8
+    T8_GEOMETRY_TYPE_UNDEFINED = 7
 end
 
 """This enumeration contains all possible geometries."""
 const t8_geometry_type_t = t8_geometry_type
-
-mutable struct t8_geometry_handler end
-
-"""This typedef holds virtual functions for the geometry handler. We need it so that we can use [`t8_geometry_handler_c`](@ref) pointers in .c files without them seeing the actual C++ code (and then not compiling) TODO: Delete this when the cmesh is a proper cpp class."""
-const t8_geometry_handler_c = t8_geometry_handler
 
 """
     t8_geometry_evaluate(cmesh, gtreeid, ref_coords, num_coords, out_coords)
@@ -13360,7 +17219,7 @@ This function returns the geometry type of a tree.
 * `cmesh`:\\[in\\] The cmesh
 * `gtreeid`:\\[in\\] The global id of the tree
 # Returns
-The geometry type of the tree with id *gtreeid*
+The geometry type of the tree with id gtreeid
 ### Prototype
 ```c
 t8_geometry_type_t t8_geometry_get_type (t8_cmesh_t cmesh, t8_gloidx_t gtreeid);
@@ -13379,7 +17238,7 @@ Check if a tree has a negative volume
 * `cmesh`:\\[in\\] The cmesh to check
 * `gtreeid`:\\[in\\] The global id of the tree
 # Returns
-True if the tree with id *gtreeid* has a negative volume. False otherwise.
+True if the tree with id gtreeid has a negative volume. False otherwise.
 ### Prototype
 ```c
 int t8_geometry_tree_negative_volume (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid);
@@ -13476,7 +17335,7 @@ Triangular interpolation between 3 points (triangle) or 4 points (tetrahedron) u
 
 # Arguments
 * `coefficients`:\\[in\\] An array of size *interpolation_dim* giving the coefficients in the reference triangle/tet used for the interpolation
-* `corner_values`:\\[in\\] An array of size 3 * *corner_value_dim* for *interpolation_dim* == 2 or 4 * *corner_value_dim* for *interpolation_dim* == 3, giving the function values of the triangle/tetrahedron for each corner (in zorder)
+* `corner_values`:\\[in\\] An array of size  3 * *corner_value_dim* for *interpolation_dim* == 2 or 4 * *corner_value_dim* for *interpolation_dim* == 3,  giving the function values of the triangle/tetrahedron for each corner (in zorder)
 * `corner_value_dim`:\\[in\\] The dimension of the *corner_values*.
 * `interpolation_dim`:\\[in\\] The dimension of the interpolation (2 for triangle, 3 for tetrahedron)
 * `evaluated_function`:\\[out\\] An array of size *corner_value_dim*, on output the result of the interpolation.
@@ -13614,7 +17473,7 @@ end
 Calculates the scaling factor for the displacement of an face through the volume of a prism element.
 
 # Arguments
-* `face`:\\[in\\] Index of the displaced face.
+* `face_index`:\\[in\\] Index of the displaced face.
 * `ref_coords`:\\[in\\] Array containing the coordinates of the reference point.
 # Returns
 The scaling factor of the face displacement at the point of the reference coordinates inside the prism volume.
@@ -13693,7 +17552,7 @@ end
 """
     t8_plane_point_inside(point_on_face, face_normal, point)
 
-Check if a point lays on the inner side of a plane of a bilinearly interpolated volume element. the plane is described by a point and the normal of the face.
+Check if a point lays on the inner side of a plane of a bilinearly interpolated volume element.  the plane is described by a point and the normal of the face.
 
 # Arguments
 * `point_on_face`:\\[in\\] A point on the plane
@@ -13730,1862 +17589,9 @@ function t8_cmesh_set_tree_vertices(cmesh, gtree_id, vertices, num_vertices)
 end
 
 """
-    t8_mat_init_xrot(mat, angle)
-
-Initialize given 3x3 matrix as rotation matrix around the x-axis with given angle.
-
-# Arguments
-* `mat`:\\[in,out\\] 3x3-matrix.
-* `angle`:\\[in\\] Rotation angle in radians.
-### Prototype
-```c
-static inline void t8_mat_init_xrot (double mat[3][3], const double angle);
-```
-"""
-function t8_mat_init_xrot(mat, angle)
-    @ccall libt8.t8_mat_init_xrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
-end
-
-"""
-    t8_mat_init_yrot(mat, angle)
-
-Initialize given 3x3 matrix as rotation matrix around the y-axis with given angle.
-
-# Arguments
-* `mat`:\\[in,out\\] 3x3-matrix.
-* `angle`:\\[in\\] Rotation angle in radians.
-### Prototype
-```c
-static inline void t8_mat_init_yrot (double mat[3][3], const double angle);
-```
-"""
-function t8_mat_init_yrot(mat, angle)
-    @ccall libt8.t8_mat_init_yrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
-end
-
-"""
-    t8_mat_init_zrot(mat, angle)
-
-Initialize given 3x3 matrix as rotation matrix around the z-axis with given angle.
-
-# Arguments
-* `mat`:\\[in,out\\] 3x3-matrix.
-* `angle`:\\[in\\] Rotation angle in radians.
-### Prototype
-```c
-static inline void t8_mat_init_zrot (double mat[3][3], const double angle);
-```
-"""
-function t8_mat_init_zrot(mat, angle)
-    @ccall libt8.t8_mat_init_zrot(mat::Ptr{NTuple{3, Cdouble}}, angle::Cdouble)::Cvoid
-end
-
-"""
-    t8_mat_mult_vec(mat, a, b)
-
-Apply matrix-matrix multiplication: b = M*a.
-
-# Arguments
-* `mat`:\\[in\\] 3x3-matrix.
-* `a`:\\[in\\] 3-vector.
-* `b`:\\[in,out\\] 3-vector.
-### Prototype
-```c
-static inline void t8_mat_mult_vec (const double mat[3][3], const double a[3], double b[3]);
-```
-"""
-function t8_mat_mult_vec(mat, a, b)
-    @ccall libt8.t8_mat_mult_vec(mat::Ptr{NTuple{3, Cdouble}}, a::Ptr{Cdouble}, b::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_mat_mult_mat(A, B, C)
-
-Apply matrix-matrix multiplication: C = A*B.
-
-# Arguments
-* `A`:\\[in\\] 3x3-matrix.
-* `B`:\\[in\\] 3x3-matrix.
-* `C`:\\[in,out\\] 3x3-matrix.
-### Prototype
-```c
-static inline void t8_mat_mult_mat (const double A[3][3], const double B[3][3], double C[3][3]);
-```
-"""
-function t8_mat_mult_mat(A, B, C)
-    @ccall libt8.t8_mat_mult_mat(A::Ptr{NTuple{3, Cdouble}}, B::Ptr{NTuple{3, Cdouble}}, C::Ptr{NTuple{3, Cdouble}})::Cvoid
-end
-
-"""
-    t8_refcount_init(rc)
-
-Initialize a reference counter to 1. It is legal if its status prior to this call is undefined.
-
-# Arguments
-* `rc`:\\[out\\] The reference counter is set to one by this call.
-### Prototype
-```c
-void t8_refcount_init (t8_refcount_t *rc);
-```
-"""
-function t8_refcount_init(rc)
-    @ccall libt8.t8_refcount_init(rc::Ptr{t8_refcount_t})::Cvoid
-end
-
-"""
-    t8_refcount_new()
-
-Create a new reference counter with count initialized to 1. Equivalent to calling [`t8_refcount_init`](@ref) on a newly allocated refcount\\_t. It is mandatory to free this with t8_refcount_destroy.
-
-# Returns
-An allocated reference counter whose count has been set to one.
-### Prototype
-```c
-t8_refcount_t * t8_refcount_new (void);
-```
-"""
-function t8_refcount_new()
-    @ccall libt8.t8_refcount_new()::Ptr{t8_refcount_t}
-end
-
-"""
-    t8_refcount_destroy(rc)
-
-Destroy a reference counter that we allocated with t8_refcount_new. Its reference count must have decreased to zero.
-
-# Arguments
-* `rc`:\\[in,out\\] Allocated, formerly valid reference counter.
-### Prototype
-```c
-void t8_refcount_destroy (t8_refcount_t *rc);
-```
-"""
-function t8_refcount_destroy(rc)
-    @ccall libt8.t8_refcount_destroy(rc::Ptr{t8_refcount_t})::Cvoid
-end
-
-# no prototype is found for this function at t8_version.h:67:1, please use with caution
-"""
-    t8_get_package_string()
-
-Return the package string of t8code. This string has the format "t8 version\\_number".
-
-# Returns
-The version string of t8code.
-### Prototype
-```c
-const char* t8_get_package_string ();
-```
-"""
-function t8_get_package_string()
-    @ccall libt8.t8_get_package_string()::Cstring
-end
-
-# no prototype is found for this function at t8_version.h:73:1, please use with caution
-"""
-    t8_get_version_number()
-
-Return the version number of t8code as a string.
-
-# Returns
-The version number of t8code as a string.
-### Prototype
-```c
-const char* t8_get_version_number ();
-```
-"""
-function t8_get_version_number()
-    @ccall libt8.t8_get_version_number()::Cstring
-end
-
-# no prototype is found for this function at t8_version.h:79:1, please use with caution
-"""
-    t8_get_version_point_string()
-
-Return the version point string.
-
-# Returns
-The version point point string.
-### Prototype
-```c
-const char* t8_get_version_point_string ();
-```
-"""
-function t8_get_version_point_string()
-    @ccall libt8.t8_get_version_point_string()::Cstring
-end
-
-# no prototype is found for this function at t8_version.h:85:1, please use with caution
-"""
-    t8_get_version_major()
-
-Return the major version number of t8code.
-
-# Returns
-The major version number of t8code.
-### Prototype
-```c
-int t8_get_version_major ();
-```
-"""
-function t8_get_version_major()
-    @ccall libt8.t8_get_version_major()::Cint
-end
-
-# no prototype is found for this function at t8_version.h:91:1, please use with caution
-"""
-    t8_get_version_minor()
-
-Return the minor version number of t8code.
-
-# Returns
-The minor version number of t8code.
-### Prototype
-```c
-int t8_get_version_minor ();
-```
-"""
-function t8_get_version_minor()
-    @ccall libt8.t8_get_version_minor()::Cint
-end
-
-# no prototype is found for this function at t8_version.h:97:1, please use with caution
-"""
-    t8_get_version_patch()
-
-Return the patch version number of t8code.
-
-# Returns
-The patch version number of t8code.
-### Prototype
-```c
-int t8_get_version_patch ();
-```
-"""
-function t8_get_version_patch()
-    @ccall libt8.t8_get_version_patch()::Cint
-end
-
-"""
-    getdelim(lineptr, n, delimiter, stream)
-
-### Prototype
-```c
-static ssize_t getdelim (char **lineptr, size_t *n, int delimiter, FILE *stream);
-```
-"""
-function getdelim(lineptr, n, delimiter, stream)
-    @ccall libt8.getdelim(lineptr::Ptr{Cstring}, n::Ptr{Cint}, delimiter::Cint, stream::Ptr{Cint})::Cint
-end
-
-"""
-    getline(lineptr, n, stream)
-
-### Prototype
-```c
-static ssize_t getline (char **lineptr, size_t *n, FILE *stream);
-```
-"""
-function getline(lineptr, n, stream)
-    @ccall libt8.getline(lineptr::Ptr{Cstring}, n::Ptr{Cint}, stream::Ptr{Cint})::Cint
-end
-
-"""
-    strsep(stringp, delim)
-
-Extract token from string up to a given delimiter.
-
-For a full description see https://linux.die.net/man/3/[`strsep`](@ref)
-
-### Prototype
-```c
-static char * strsep (char **stringp, const char *delim);
-```
-"""
-function strsep(stringp, delim)
-    @ccall libt8.strsep(stringp::Ptr{Cstring}, delim::Cstring)::Cstring
-end
-
-"""
-    t8_scheme_ref(scheme)
-
-Increase the reference counter of a scheme.
-
-# Arguments
-* `scheme`:\\[in,out\\] On input, this scheme must be alive, that is, exist with positive reference count.
-### Prototype
-```c
-void t8_scheme_ref (t8_scheme_c *scheme);
-```
-"""
-function t8_scheme_ref(scheme)
-    @ccall libt8.t8_scheme_ref(scheme::Ptr{t8_scheme_c})::Cvoid
-end
-
-"""
-    t8_scheme_unref(pscheme)
-
-Decrease the reference counter of a scheme. If the counter reaches zero, this scheme is destroyed.
-
-# Arguments
-* `pscheme`:\\[in,out\\] On input, the scheme pointed to must exist with positive reference count. If the reference count reaches zero, the scheme is destroyed and this pointer set to NULL. Otherwise, the pointer is not changed and the scheme is not modified in other ways.
-### Prototype
-```c
-void t8_scheme_unref (t8_scheme_c **pscheme);
-```
-"""
-function t8_scheme_unref(pscheme)
-    @ccall libt8.t8_scheme_unref(pscheme::Ptr{Ptr{t8_scheme_c}})::Cvoid
-end
-
-"""
-    t8_element_get_element_size(scheme, tree_class)
-
-Return the size of any element of a given class.
-
-# Returns
-The size of an element of class **ts**. We provide a default implementation of this routine that should suffice for most use cases.
-### Prototype
-```c
-size_t t8_element_get_element_size (const t8_scheme_c *scheme, const t8_eclass_t tree_class);
-```
-"""
-function t8_element_get_element_size(scheme, tree_class)
-    @ccall libt8.t8_element_get_element_size(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Csize_t
-end
-
-"""
-    t8_element_refines_irregular(scheme, tree_class)
-
-Returns true, if there is one element in the tree, that does not refine into 2^dim children. Returns false otherwise.
-
-### Prototype
-```c
-int t8_element_refines_irregular (const t8_scheme_c *scheme, const t8_eclass_t tree_class);
-```
-"""
-function t8_element_refines_irregular(scheme, tree_class)
-    @ccall libt8.t8_element_refines_irregular(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Cint
-end
-
-"""
-    t8_element_get_maxlevel(scheme, tree_class)
-
-Return the maximum allowed level for any element of a given class.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-# Returns
-The maximum allowed level for elements of class **ts**.
-### Prototype
-```c
-int t8_element_get_maxlevel (const t8_scheme_c *scheme, const t8_eclass_t tree_class);
-```
-"""
-function t8_element_get_maxlevel(scheme, tree_class)
-    @ccall libt8.t8_element_get_maxlevel(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Cint
-end
-
-"""
-    t8_element_get_level(scheme, tree_class, element)
-
-Return the level of an element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The level of *element*.
-### Prototype
-```c
-int t8_element_get_level (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_level(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_level(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_copy(scheme, tree_class, source, dest)
-
-Copy all entries of **source** to **dest**. **dest** must be an existing element. No memory is allocated by this function.
-
-!!! note
-
-    *source* and *dest* may point to the same element.
-
-# Arguments
-* `scheme`:\\[in\\] Implementation of a class scheme.
-* `tree_class`:\\[in\\] The eclass of the current tree.
-* `source`:\\[in\\] The element whose entries will be copied to **dest**.
-* `dest`:\\[in,out\\] This element's entries will be overwritten with the entries of **source**.
-### Prototype
-```c
-void t8_element_copy (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *source, t8_element_t *dest);
-```
-"""
-function t8_element_copy(scheme, tree_class, source, dest)
-    @ccall libt8.t8_element_copy(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, source::Ptr{t8_element_t}, dest::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_compare(scheme, tree_class, elem1, elem2)
-
-Compare two elements with respect to the scheme.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem1`:\\[in\\] The first element.
-* `elem2`:\\[in\\] The second element.
-# Returns
-negative if elem1 < elem2, zero if elem1 equals elem2 and positive if elem1 > elem2. If elem2 is a copy of elem1 then the elements are equal.
-### Prototype
-```c
-int t8_element_compare (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1, const t8_element_t *elem2);
-```
-"""
-function t8_element_compare(scheme, tree_class, elem1, elem2)
-    @ccall libt8.t8_element_compare(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_is_equal(scheme, tree_class, elem1, elem2)
-
-Check if two elements are equal.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem1`:\\[in\\] The first element.
-* `elem2`:\\[in\\] The second element.
-# Returns
-1 if the elements are equal, 0 if they are not equal
-### Prototype
-```c
-int t8_element_is_equal (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1, const t8_element_t *elem2);
-```
-"""
-function t8_element_is_equal(scheme, tree_class, elem1, elem2)
-    @ccall libt8.t8_element_is_equal(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cint
-end
-
-"""
-    element_is_refinable(scheme, tree_class, element)
-
-Indicates if an element is refinable. Possible reasons for being not refinable could be that the element has reached its max level.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element to check.
-# Returns
-1 if the element is refinable, 0 otherwise.
-### Prototype
-```c
-int element_is_refinable (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function element_is_refinable(scheme, tree_class, element)
-    @ccall libt8.element_is_refinable(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_parent(scheme, tree_class, element, parent)
-
-Compute the parent of a given element **element** and store it in **parent**. **parent** needs to be an existing element. No memory is allocated by this function. **element** and **parent** can point to the same element, then the entries of **element** are overwritten by the ones of its parent.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element whose parent will be computed.
-* `parent`:\\[in,out\\] This element's entries will be overwritten by those of **element**'s parent. The storage for this element must exist and match the element class of the parent.
-### Prototype
-```c
-void t8_element_get_parent (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, t8_element_t *parent);
-```
-"""
-function t8_element_get_parent(scheme, tree_class, element, parent)
-    @ccall libt8.t8_element_get_parent(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, parent::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_num_siblings(scheme, tree_class, element)
-
-Compute the number of siblings of an element. That is the number of  Children of its parent.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The number of siblings of *element*. Note that this number is >= 1, since we count the element itself as a sibling.
-### Prototype
-```c
-int t8_element_get_num_siblings (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_num_siblings(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_num_siblings(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_sibling(scheme, tree_class, elem, sibid, sibling)
-
-Compute a specific sibling of a given element **element** and store it in **sibling**. **sibling** needs to be an existing element. No memory is allocated by this function. **element** and **sibling** can point to the same element, then the entries of **element** are overwritten by the ones of its i-th sibling.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem`:\\[in\\] The element whose sibling will be computed.
-* `sibid`:\\[in\\] The id of the sibling computed.
-* `sibling`:\\[in,out\\] This element's entries will be overwritten by those of **element**'s sibid-th sibling. The storage for this element must exist and match the element class of the sibling.
-### Prototype
-```c
-void t8_element_get_sibling (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem, const int sibid, t8_element_t *sibling);
-```
-"""
-function t8_element_get_sibling(scheme, tree_class, elem, sibid, sibling)
-    @ccall libt8.t8_element_get_sibling(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem::Ptr{t8_element_t}, sibid::Cint, sibling::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_num_corners(scheme, tree_class, element)
-
-Compute the number of corners of an element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The number of corners of *element*.
-### Prototype
-```c
-int t8_element_get_num_corners (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_num_corners(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_num_corners(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_num_faces(scheme, tree_class, element)
-
-Compute the number of faces of an element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The number of faces of *element*.
-### Prototype
-```c
-int t8_element_get_num_faces (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_num_faces(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_num_faces(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_max_num_faces(scheme, tree_class, element)
-
-Compute the maximum number of faces of a given element and all of its descendants.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The number of faces of *element*.
-### Prototype
-```c
-int t8_element_get_max_num_faces (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_max_num_faces(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_max_num_faces(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_num_children(scheme, tree_class, element)
-
-Compute the number of children of an element when it is refined.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-# Returns
-The number of children of *element*.
-### Prototype
-```c
-int t8_element_get_num_children (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_num_children(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_num_children(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_get_max_num_children(scheme, tree_class)
-
-Return the max number of children of an eclass.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-# Returns
-The max number of children of *element*.
-### Prototype
-```c
-int t8_get_max_num_children (const t8_scheme_c *scheme, const t8_eclass_t tree_class);
-```
-"""
-function t8_get_max_num_children(scheme, tree_class)
-    @ccall libt8.t8_get_max_num_children(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t)::Cint
-end
-
-"""
-    t8_element_get_num_face_children(scheme, tree_class, element, face)
-
-Compute the number of children of an element's face when the element is refined.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] A face of *element*.
-# Returns
-The number of children of *face* if *element* is to be refined.
-### Prototype
-```c
-int t8_element_get_num_face_children (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face);
-```
-"""
-function t8_element_get_num_face_children(scheme, tree_class, element, face)
-    @ccall libt8.t8_element_get_num_face_children(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint)::Cint
-end
-
-"""
-    t8_element_get_face_corner(scheme, tree_class, element, face, corner)
-
-Return the corner number of an element's face corner. Example quad: 2 x --- x 3 | | | | face 1 0 x --- x 1 Thus for face = 1 the output is: corner=0 : 1, corner=1: 3
-
-The order in which the corners must be given is determined by the eclass of *element*: LINE/QUAD/TRIANGLE: No specific order. HEX : In Z-order of the face starting with the lowest corner number. TET : Starting with the lowest corner number counterclockwise as seen from 'outside' of the element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] A face index for *element*.
-* `corner`:\\[in\\] A corner index for the face 0 <= *corner* < num\\_face\\_corners.
-# Returns
-The corner number of the *corner*-th vertex of *face*.
-### Prototype
-```c
-int t8_element_get_face_corner (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, const int corner);
-```
-"""
-function t8_element_get_face_corner(scheme, tree_class, element, face, corner)
-    @ccall libt8.t8_element_get_face_corner(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, corner::Cint)::Cint
-end
-
-"""
-    t8_element_get_corner_face(scheme, tree_class, element, corner, face)
-
-Compute the face numbers of the faces sharing an element's corner. Example quad: 2 x --- x 3 | | | | face 1 0 x --- x 1 face 2 Thus for corner = 1 the output is: face=0 : 2, face=1: 1
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `corner`:\\[in\\] A corner index for the face.
-* `face`:\\[in\\] A face index for *corner*.
-# Returns
-The face number of the *face*-th face at *corner*.
-### Prototype
-```c
-int t8_element_get_corner_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int corner, const int face);
-```
-"""
-function t8_element_get_corner_face(scheme, tree_class, element, corner, face)
-    @ccall libt8.t8_element_get_corner_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, corner::Cint, face::Cint)::Cint
-end
-
-"""
-    t8_element_get_child(scheme, tree_class, element, childid, child)
-
-Construct the child element of a given number.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] This must be a valid element, bigger than maxlevel.
-* `childid`:\\[in\\] The number of the child to construct.
-* `child`:\\[in,out\\] The storage for this element must exist. On output, a valid element. It is valid to call this function with element = child.
-### Prototype
-```c
-void t8_element_get_child (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int childid, t8_element_t *child);
-```
-"""
-function t8_element_get_child(scheme, tree_class, element, childid, child)
-    @ccall libt8.t8_element_get_child(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, childid::Cint, child::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_children(scheme, tree_class, element, length, c)
-
-Construct all children of a given element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] This must be a valid element, bigger than maxlevel.
-* `length`:\\[in\\] The length of the output array *c* must match the number of children.
-* `c`:\\[in,out\\] The storage for these *length* elements must exist and match the element class in the children's ordering. On output, all children are valid. It is valid to call this function with element = c[0].
-# See also
-t8\\_element\\_num\\_children
-
-### Prototype
-```c
-void t8_element_get_children (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int length, t8_element_t *c[]);
-```
-"""
-function t8_element_get_children(scheme, tree_class, element, length, c)
-    @ccall libt8.t8_element_get_children(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, length::Cint, c::Ptr{Ptr{t8_element_t}})::Cvoid
-end
-
-"""
-    t8_element_get_child_id(scheme, tree_class, element)
-
-Compute the child id of an element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] This must be a valid element.
-# Returns
-The child id of element.
-### Prototype
-```c
-int t8_element_get_child_id (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_child_id(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_child_id(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cint
-end
-
-"""
-    t8_element_get_ancestor_id(scheme, tree_class, element, level)
-
-Compute the ancestor id of an element, that is the child id at a given level.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] This must be a valid element.
-* `level`:\\[in\\] A refinement level. Must satisfy *level* < element.level
-# Returns
-The child\\_id of *element* in regard to its *level* ancestor.
-### Prototype
-```c
-int t8_element_get_ancestor_id (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int level);
-```
-"""
-function t8_element_get_ancestor_id(scheme, tree_class, element, level)
-    @ccall libt8.t8_element_get_ancestor_id(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, level::Cint)::Cint
-end
-
-"""
-    t8_elements_are_family(scheme, tree_class, fam)
-
-Query whether a given set of elements is a family or not.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `fam`:\\[in\\] An array of as many elements as an element of class **scheme** has children.
-# Returns
-Zero if **fam** is not a family, nonzero if it is.
-### Prototype
-```c
-int t8_elements_are_family (const t8_scheme_c *scheme, const t8_eclass_t tree_class, t8_element_t *const *fam);
-```
-"""
-function t8_elements_are_family(scheme, tree_class, fam)
-    @ccall libt8.t8_elements_are_family(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, fam::Ptr{Ptr{t8_element_t}})::Cint
-end
-
-"""
-    t8_element_get_nca(scheme, tree_class, elem1, elem2, nca)
-
-Compute the nearest common ancestor of two elements. That is, the element with highest level that still has both given elements as descendants.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem1`:\\[in\\] The first of the two input elements.
-* `elem2`:\\[in\\] The second of the two input elements.
-* `nca`:\\[in,out\\] The storage for this element must exist and match the element class of the child. On output the unique nearest common ancestor of **elem1** and **elem2**.
-### Prototype
-```c
-void t8_element_get_nca (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1, const t8_element_t *elem2, t8_element_t *nca);
-```
-"""
-function t8_element_get_nca(scheme, tree_class, elem1, elem2, nca)
-    @ccall libt8.t8_element_get_nca(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t}, nca::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_face_shape(scheme, tree_class, element, face)
-
-Compute the shape of the face of an element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] A face of *element*.
-# Returns
-The element shape of the face. I.e. T8\\_ECLASS\\_LINE for quads, T8\\_ECLASS\\_TRIANGLE for tets and depending on the face number either T8\\_ECLASS\\_QUAD or T8\\_ECLASS\\_TRIANGLE for prisms.
-### Prototype
-```c
-t8_element_shape_t t8_element_get_face_shape (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face);
-```
-"""
-function t8_element_get_face_shape(scheme, tree_class, element, face)
-    @ccall libt8.t8_element_get_face_shape(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint)::t8_element_shape_t
-end
-
-"""
-    t8_element_get_children_at_face(scheme, tree_class, element, face, children, num_children, child_indices)
-
-Given an element and a face of the element, compute all children of the element that touch the face.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] A face of *element*.
-* `children`:\\[in,out\\] Allocated elements, in which the children of *element* that share a face with *face* are stored. They will be stored in order of their linear id.
-* `num_children`:\\[in\\] The number of elements in *children*. Must match the number of children that touch *face*. t8_scheme::element_get_num_face_children
-* `child_indices`:\\[in,out\\] If not NULL, an array of num\\_children integers must be given, on output its i-th entry is the child\\_id of the i-th face\\_child. It is valid to call this function with element = children[0].
-### Prototype
-```c
-void t8_element_get_children_at_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, t8_element_t *children[], const int num_children, int *child_indices);
-```
-"""
-function t8_element_get_children_at_face(scheme, tree_class, element, face, children, num_children, child_indices)
-    @ccall libt8.t8_element_get_children_at_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, children::Ptr{Ptr{t8_element_t}}, num_children::Cint, child_indices::Ptr{Cint})::Cvoid
-end
-
-"""
-    t8_element_face_get_child_face(scheme, tree_class, element, face, face_child)
-
-Given a face of an element and a child number of a child of that face, return the face number of the child of the element that matches the child face.
-
-```c++
-  x ---- x   x      x           x ---- x
-  |      |   |      |           |   |  | <-- f
-  |      |   |      x           |   x--x
-  |      |   |                  |      |
-  x ---- x   x                  x ---- x
-   element    face  face_child    Returns the face number f
-```
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] Then number of the face.
-* `face_child`:\\[in\\] A number 0 <= *face_child* < num\\_face\\_children, specifying a child of *element* that shares a face with *face*. These children are counted in linear order. This coincides with the order of children from a call to t8_scheme::element_get_children_at_face.
-# Returns
-The face number of the face of a child of *element* that coincides with *face_child*.
-### Prototype
-```c
-int t8_element_face_get_child_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, const int face_child);
-```
-"""
-function t8_element_face_get_child_face(scheme, tree_class, element, face, face_child)
-    @ccall libt8.t8_element_face_get_child_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, face_child::Cint)::Cint
-end
-
-"""
-    t8_element_face_get_parent_face(scheme, tree_class, element, face)
-
-Given a face of an element return the face number of the parent of the element that matches the element's face. Or return -1 if no face of the parent matches the face.
-
-!!! note
-
-    For the root element this function always returns *face*.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] Then number of the face.
-# Returns
-If *face* of *element* is also a face of *element*'s parent, the face number of this face. Otherwise -1.
-### Prototype
-```c
-int t8_element_face_get_parent_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face);
-```
-"""
-function t8_element_face_get_parent_face(scheme, tree_class, element, face)
-    @ccall libt8.t8_element_face_get_parent_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint)::Cint
-end
-
-"""
-    t8_element_get_tree_face(scheme, tree_class, element, face)
-
-Given an element and a face of this element. If the face lies on the tree boundary, return the face number of the tree face. If not the return value is arbitrary.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element.
-* `face`:\\[in\\] The index of a face of *element*.
-# Returns
-The index of the tree face that *face* is a subface of, if *face* is on a tree boundary. Any arbitrary integer if *is* not at a tree boundary.
-### Prototype
-```c
-int t8_element_get_tree_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face);
-```
-"""
-function t8_element_get_tree_face(scheme, tree_class, element, face)
-    @ccall libt8.t8_element_get_tree_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint)::Cint
-end
-
-"""
-    t8_element_transform_face(scheme, tree_class, elem1, elem2, orientation, sign, is_smaller_face)
-
-Suppose we have two trees that share a common face f. Given an element e that is a subface of f in one of the trees and given the orientation of the tree connection, construct the face element of the respective tree neighbor that logically coincides with e but lies in the coordinate system of the neighbor tree.
-
-!!! note
-
-    *elem1* and *elem2* may point to the same element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem1`:\\[in\\] The face element.
-* `elem2`:\\[in,out\\] On return the face element *elem1* with respect to the coordinate system of the other tree.
-* `orientation`:\\[in\\] The orientation of the tree-tree connection.
-* `sign`:\\[in\\] Depending on the topological orientation of the two tree faces, either 0 (both faces have opposite orientation) or 1 (both faces have the same top. orientation). t8_eclass_face_orientation
-* `is_smaller_face`:\\[in\\] Flag to declare whether *elem1* belongs to the smaller face. A face f of tree T is smaller than f' of T' if either the eclass of T is smaller or if the classes are equal and f<f'. The orientation is defined in relation to the smaller face.
-# See also
-[`t8_cmesh_set_join`](@ref)
-
-### Prototype
-```c
-void t8_element_transform_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1, t8_element_t *elem2, const int orientation, const int sign, const int is_smaller_face);
-```
-"""
-function t8_element_transform_face(scheme, tree_class, elem1, elem2, orientation, sign, is_smaller_face)
-    @ccall libt8.t8_element_transform_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t}, orientation::Cint, sign::Cint, is_smaller_face::Cint)::Cvoid
-end
-
-"""
-    t8_element_extrude_face(scheme, tree_class, face, element, root_face)
-
-Given a boundary face inside a root tree's face construct the element inside the root tree that has the given face as a face.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `face`:\\[in\\] A face element.
-* `element`:\\[in,out\\] An allocated element. The entries will be filled with the data of the element that has *face* as a face and lies within the root tree.
-* `root_face`:\\[in\\] The index of the face of the root tree in which *face* lies.
-# Returns
-The face number of the face of *element* that coincides with *face*.
-### Prototype
-```c
-int t8_element_extrude_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *face, t8_element_t *element, int root_face);
-```
-"""
-function t8_element_extrude_face(scheme, tree_class, face, element, root_face)
-    @ccall libt8.t8_element_extrude_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, face::Ptr{t8_element_t}, element::Ptr{t8_element_t}, root_face::Cint)::Cint
-end
-
-"""
-    t8_element_get_boundary_face(scheme, tree_class, element, face, boundary)
-
-Construct the boundary element at a specific face.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The input element.
-* `face`:\\[in\\] The index of the face of which to construct the boundary element.
-* `boundary`:\\[in,out\\] An allocated element of dimension of *element* minus 1. The entries will be filled with the entries of the face of *element*. If *element* is of class T8\\_ECLASS\\_VERTEX, then *boundary* must be NULL and will not be modified.
-### Prototype
-```c
-void t8_element_get_boundary_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, t8_element_t *boundary);
-```
-"""
-function t8_element_get_boundary_face(scheme, tree_class, element, face, boundary)
-    @ccall libt8.t8_element_get_boundary_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, boundary::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_first_descendant_face(scheme, tree_class, element, face, first_desc, level)
-
-Construct the first descendant of an element at a given level that touches a given face.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The input element.
-* `face`:\\[in\\] A face of *element*.
-* `first_desc`:\\[in,out\\] An allocated element. This element's data will be filled with the data of the first descendant of *element* that shares a face with *face*.
-* `level`:\\[in\\] The level, at which the first descendant is constructed
-### Prototype
-```c
-void t8_element_get_first_descendant_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, t8_element_t *first_desc, const int level);
-```
-"""
-function t8_element_get_first_descendant_face(scheme, tree_class, element, face, first_desc, level)
-    @ccall libt8.t8_element_get_first_descendant_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, first_desc::Ptr{t8_element_t}, level::Cint)::Cvoid
-end
-
-"""
-    t8_element_get_last_descendant_face(scheme, tree_class, element, face, last_desc, level)
-
-Construct the last descendant of an element at a given level that touches a given face.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The input element.
-* `face`:\\[in\\] A face of *element*.
-* `last_desc`:\\[in,out\\] An allocated element. This element's data will be filled with the data of the last descendant of *element* that shares a face with *face*.
-* `level`:\\[in\\] The level, at which the last descendant is constructed
-### Prototype
-```c
-void t8_element_get_last_descendant_face (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face, t8_element_t *last_desc, const int level);
-```
-"""
-function t8_element_get_last_descendant_face(scheme, tree_class, element, face, last_desc, level)
-    @ccall libt8.t8_element_get_last_descendant_face(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint, last_desc::Ptr{t8_element_t}, level::Cint)::Cvoid
-end
-
-"""
-    t8_element_is_root_boundary(scheme, tree_class, element, face)
-
-Compute whether a given element shares a given face with its root tree.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The input element.
-* `face`:\\[in\\] A face of *element*.
-# Returns
-True if *face* is a subface of the element's root element.
-### Prototype
-```c
-int t8_element_is_root_boundary (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int face);
-```
-"""
-function t8_element_is_root_boundary(scheme, tree_class, element, face)
-    @ccall libt8.t8_element_is_root_boundary(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, face::Cint)::Cint
-end
-
-"""
-    t8_element_get_face_neighbor_inside(scheme, tree_class, element, neigh, face, neigh_face)
-
-Construct the face neighbor of a given element if this face neighbor is inside the root tree. Return 0 otherwise.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element to be considered.
-* `neigh`:\\[in,out\\] If the face neighbor of *element* along *face* is inside the root tree, this element's data is filled with the data of the face neighbor. Otherwise the data can be modified arbitrarily.
-* `face`:\\[in\\] The number of the face along which the neighbor should be constructed.
-* `neigh_face`:\\[out\\] The number of *face* as viewed from *neigh*. An arbitrary value, if the neighbor is not inside the root tree.
-# Returns
-True if *neigh* is inside the root tree. False if not. In this case *neigh*'s data can be arbitrary on output.
-### Prototype
-```c
-int t8_element_get_face_neighbor_inside (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, t8_element_t *neigh, const int face, int *neigh_face);
-```
-"""
-function t8_element_get_face_neighbor_inside(scheme, tree_class, element, neigh, face, neigh_face)
-    @ccall libt8.t8_element_get_face_neighbor_inside(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, neigh::Ptr{t8_element_t}, face::Cint, neigh_face::Ptr{Cint})::Cint
-end
-
-"""
-    t8_element_get_shape(scheme, tree_class, element)
-
-Return the shape of an allocated element according its type. For example, a child of an element can be an element of a different shape and has to be handled differently - according to its shape.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element to be considered
-# Returns
-The shape of the element as an eclass
-### Prototype
-```c
-t8_element_shape_t t8_element_get_shape (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element);
-```
-"""
-function t8_element_get_shape(scheme, tree_class, element)
-    @ccall libt8.t8_element_get_shape(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::t8_element_shape_t
-end
-
-"""
-    t8_element_set_linear_id(scheme, tree_class, element, level, id)
-
-Initialize the entries of an allocated element according to a given linear id in a uniform refinement.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in,out\\] The element whose entries will be set.
-* `level`:\\[in\\] The level of the uniform refinement to consider.
-* `id`:\\[in\\] The linear id. id must fulfil 0 <= id < 'number of leaves in the uniform refinement'
-### Prototype
-```c
-void t8_element_set_linear_id (const t8_scheme_c *scheme, const t8_eclass_t tree_class, t8_element_t *element, const int level, const t8_linearidx_t id);
-```
-"""
-function t8_element_set_linear_id(scheme, tree_class, element, level, id)
-    @ccall libt8.t8_element_set_linear_id(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, level::Cint, id::t8_linearidx_t)::Cvoid
-end
-
-"""
-    t8_element_get_linear_id(scheme, tree_class, element, level)
-
-Compute the linear id of a given element in a hypothetical uniform refinement of a given level.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element whose id we compute.
-* `level`:\\[in\\] The level of the uniform refinement to consider.
-# Returns
-The linear id of the element.
-### Prototype
-```c
-t8_linearidx_t t8_element_get_linear_id (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int level);
-```
-"""
-function t8_element_get_linear_id(scheme, tree_class, element, level)
-    @ccall libt8.t8_element_get_linear_id(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, level::Cint)::t8_linearidx_t
-end
-
-"""
-    t8_element_get_first_descendant(scheme, tree_class, element, desc, level)
-
-Compute the first descendant of a given element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element whose descendant is computed.
-* `desc`:\\[out\\] The first element in a uniform refinement of *element* at level *level*.
-* `level`:\\[in\\] The uniform refinement level at which the descendant is computed. *level* must be greater or equal to the level of *element*.
-### Prototype
-```c
-void t8_element_get_first_descendant (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, t8_element_t *desc, const int level);
-```
-"""
-function t8_element_get_first_descendant(scheme, tree_class, element, desc, level)
-    @ccall libt8.t8_element_get_first_descendant(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, desc::Ptr{t8_element_t}, level::Cint)::Cvoid
-end
-
-"""
-    t8_element_get_last_descendant(scheme, tree_class, element, desc, level)
-
-Compute the last descendant of a given element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element whose descendant is computed.
-* `desc`:\\[out\\] The last element in a uniform refinement of *element* of the maximum possible level.
-* `level`:\\[in\\] The uniform refinement level at which the descendant is computed. *level* must be greater or equal to the level of *element*.
-### Prototype
-```c
-void t8_element_get_last_descendant (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, t8_element_t *desc, const int level);
-```
-"""
-function t8_element_get_last_descendant(scheme, tree_class, element, desc, level)
-    @ccall libt8.t8_element_get_last_descendant(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, desc::Ptr{t8_element_t}, level::Cint)::Cvoid
-end
-
-"""
-    t8_element_get_successor(scheme, tree_class, elem1, elem2)
-
-Construct the successor in a uniform refinement of a given element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `elem1`:\\[in\\] The element whose successor should be constructed.
-* `elem2`:\\[in,out\\] The element whose entries will be set.
-### Prototype
-```c
-void t8_element_get_successor (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1, t8_element_t *elem2);
-```
-"""
-function t8_element_get_successor(scheme, tree_class, elem1, elem2)
-    @ccall libt8.t8_element_get_successor(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elem1::Ptr{t8_element_t}, elem2::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_get_vertex_reference_coords(scheme, tree_class, element, vertex, coords)
-
-Compute the coordinates of a given element vertex inside a reference tree that is embedded into [0,1]^d (d = dimension).
-
-!!! warning
-
-    coords should be zero-initialized, as only the first d coords will be set, but when used elsewhere all coords might be used.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element to be considered.
-* `vertex`:\\[in\\] The id of the vertex whose coordinates shall be computed.
-* `coords`:\\[out\\] An array of at least as many doubles as the element's dimension whose entries will be filled with the coordinates of *vertex*.
-### Prototype
-```c
-void t8_element_get_vertex_reference_coords (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int vertex, double coords[]);
-```
-"""
-function t8_element_get_vertex_reference_coords(scheme, tree_class, element, vertex, coords)
-    @ccall libt8.t8_element_get_vertex_reference_coords(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, vertex::Cint, coords::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_element_get_reference_coords(scheme, tree_class, element, ref_coords, num_coords, out_coords)
-
-Convert points in the reference space of an element to points in the reference space of the tree.
-
-```c++
- [0,1]^\\mathrm{dim} 
-```
-
-of the point in the reference space of the element.
-
-```c++
- dim
-```
-
--sized coordinates to evaluate.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of the current tree.
-* `element`:\\[in\\] The element.
-* `ref_coords`:\\[in\\] The coordinates
-* `num_coords`:\\[in\\] Number of
-* `out_coords`:\\[out\\] The coordinates of the points in the reference space of the tree.
-### Prototype
-```c
-void t8_element_get_reference_coords (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const double *ref_coords, const size_t num_coords, double out_coords[]);
-```
-"""
-function t8_element_get_reference_coords(scheme, tree_class, element, ref_coords, num_coords, out_coords)
-    @ccall libt8.t8_element_get_reference_coords(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, ref_coords::Ptr{Cdouble}, num_coords::Csize_t, out_coords::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_element_count_leaves(scheme, tree_class, element, level)
-
-Count how many leaf descendants of a given uniform level an element would produce.
-
-Example: If *element* is a line element that refines into 2 line elements on each level, then the return value is max(0, 2^{*level* - level(*t*)}). Thus, if *element*'s level is 0, and *level* = 3, the return value is 2^3 = 8.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in\\] The element to be checked.
-* `level`:\\[in\\] A refinement level.
-# Returns
-Suppose *element* is uniformly refined up to level *level*. The return value is the resulting number of elements (of the given level). If *level* < [`t8_element_get_level`](@ref)(element), the return value should be 0.
-### Prototype
-```c
-t8_gloidx_t t8_element_count_leaves (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, const int level);
-```
-"""
-function t8_element_count_leaves(scheme, tree_class, element, level)
-    @ccall libt8.t8_element_count_leaves(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, level::Cint)::t8_gloidx_t
-end
-
-"""
-    t8_element_count_leaves_from_root(scheme, tree_class, level)
-
-Count how many leaf descendants of a given uniform level the root element will produce.
-
-This is a convenience function, and can be implemented via t8_element_count_leaves.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `level`:\\[in\\] A refinement level.
-# Returns
-The value of t8_element_count_leaves if the input element is the root (level 0) element.
-### Prototype
-```c
-t8_gloidx_t t8_element_count_leaves_from_root (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int level);
-```
-"""
-function t8_element_count_leaves_from_root(scheme, tree_class, level)
-    @ccall libt8.t8_element_count_leaves_from_root(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, level::Cint)::t8_gloidx_t
-end
-
-"""
-    t8_element_to_string(scheme, tree_class, element, debug_string, string_size)
-
-Fill a string with readable information about the element
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of the current tree.
-* `element`:\\[in\\] The element to translate into human-readable information.
-* `debug_string`:\\[in,out\\] The string to fill.
-* `string_size`:\\[in\\] The length of *debug_string*.
-### Prototype
-```c
-void t8_element_to_string (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *element, char *debug_string, const int string_size);
-```
-"""
-function t8_element_to_string(scheme, tree_class, element, debug_string, string_size)
-    @ccall libt8.t8_element_to_string(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t}, debug_string::Cstring, string_size::Cint)::Cvoid
-end
-
-"""
-    t8_element_new(scheme, tree_class, length, elems)
-
-Allocate memory for an array of elements of a given class and initialize them.
-
-!!! note
-
-    Not every element that is created in t8code will be created by a call to this function. However, if an element is not created using t8_element_new, then it is guaranteed that t8_scheme::element_init is called on it.
-
-!!! note
-
-    In debugging mode, an element that was created with t8_element_new must pass t8_element_is_valid.
-
-!!! note
-
-    If an element was created by t8_element_new then t8_scheme::element_init may not be called for it. Thus, t8_element_new should initialize an element in the same way as a call to t8_scheme::element_init would.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `length`:\\[in\\] The number of elements to be allocated.
-* `elems`:\\[in,out\\] On input an array of **length** many unallocated element pointers. On output all these pointers will point to an allocated and initialized element.
-# See also
-[`t8_element_init`](@ref), element\\_is\\_valid
-
-### Prototype
-```c
-void t8_element_new (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int length, t8_element_t **elems);
-```
-"""
-function t8_element_new(scheme, tree_class, length, elems)
-    @ccall libt8.t8_element_new(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, length::Cint, elems::Ptr{Ptr{t8_element_t}})::Cvoid
-end
-
-"""
-    t8_element_init(scheme, tree_class, length, elem)
-
-Initialize an array of allocated elements.
-
-!!! note
-
-    In debugging mode, an element that was passed to t8_element_init must pass t8_element_is_valid.
-
-!!! note
-
-    If an element was created by t8_element_new then t8_element_init may not be called for it. Thus, t8_element_init should initialize an element in the same way as a call to t8_element_new would.
-
-!!! note
-
-    Every call to
-
-# Arguments
-* `scheme`:\\[in\\] The scheme to use.
-* `tree_class`:\\[in\\] The eclass of the current tree.
-* `length`:\\[in\\] The number of elements to be initialized.
-* `elem`:\\[in,out\\] On input an array of *length* many allocated elements.
-# See also
-[`t8_element_init`](@ref) must be matched by a call to, [`t8_element_deinit`](@ref), [`t8_element_deinit`](@ref), [`t8_element_new`](@ref), t8\\_element\\_is\\_valid
-
-### Prototype
-```c
-void t8_element_init (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int length, t8_element_t *elem);
-```
-"""
-function t8_element_init(scheme, tree_class, length, elem)
-    @ccall libt8.t8_element_init(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, length::Cint, elem::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_deinit(scheme, tree_class, length, elems)
-
-Deinitialize an array of allocated elements.
-
-!!! note
-
-    Call this function if you called t8_element_init on the element pointers.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme to use.
-* `tree_class`:\\[in\\] The eclass of the current tree.
-* `length`:\\[in\\] The number of elements to be deinitialized.
-* `elems`:\\[in,out\\] On input an array of *length* many allocated and initialized elements, on output an array of *length* many allocated, but not initialized elements.
-# See also
-[`t8_element_init`](@ref)
-
-### Prototype
-```c
-void t8_element_deinit (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int length, t8_element_t *elems);
-```
-"""
-function t8_element_deinit(scheme, tree_class, length, elems)
-    @ccall libt8.t8_element_deinit(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, length::Cint, elems::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_destroy(scheme, tree_class, length, elems)
-
-Deallocate an array of elements.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `length`:\\[in\\] The number of elements in the array.
-* `elems`:\\[in,out\\] On input an array of **length** many allocated element pointers. On output all these pointers will be freed. **element** itself will not be freed by this function.
-### Prototype
-```c
-void t8_element_destroy (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int length, t8_element_t **elems);
-```
-"""
-function t8_element_destroy(scheme, tree_class, length, elems)
-    @ccall libt8.t8_element_destroy(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, length::Cint, elems::Ptr{Ptr{t8_element_t}})::Cvoid
-end
-
-"""
-    t8_element_set_to_root(scheme, tree_class, element)
-
-Fills an element with the root element.
-
-# Arguments
-* `scheme`:\\[in\\] The scheme of the forest.
-* `tree_class`:\\[in\\] The eclass of tree the elements are part of.
-* `element`:\\[in,out\\] The element to be filled with root.
-### Prototype
-```c
-void t8_element_set_to_root (const t8_scheme_c *scheme, const t8_eclass_t tree_class, t8_element_t *element);
-```
-"""
-function t8_element_set_to_root(scheme, tree_class, element)
-    @ccall libt8.t8_element_set_to_root(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, element::Ptr{t8_element_t})::Cvoid
-end
-
-"""
-    t8_element_MPI_Pack(scheme, tree_class, elements, count, send_buffer, buffer_size, position, comm)
-
-### Prototype
-```c
-void t8_element_MPI_Pack (const t8_scheme_c *scheme, const t8_eclass_t tree_class, t8_element_t **const elements, const unsigned int count, void *send_buffer, const int buffer_size, int *position, sc_MPI_Comm comm);
-```
-"""
-function t8_element_MPI_Pack(scheme, tree_class, elements, count, send_buffer, buffer_size, position, comm)
-    @ccall libt8.t8_element_MPI_Pack(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, elements::Ptr{Ptr{t8_element_t}}, count::Cuint, send_buffer::Ptr{Cvoid}, buffer_size::Cint, position::Ptr{Cint}, comm::MPI_Comm)::Cvoid
-end
-
-"""
-    t8_element_MPI_Pack_size(scheme, tree_class, count, comm, pack_size)
-
-### Prototype
-```c
-void t8_element_MPI_Pack_size (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const unsigned int count, sc_MPI_Comm comm, int *pack_size);
-```
-"""
-function t8_element_MPI_Pack_size(scheme, tree_class, count, comm, pack_size)
-    @ccall libt8.t8_element_MPI_Pack_size(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, count::Cuint, comm::MPI_Comm, pack_size::Ptr{Cint})::Cvoid
-end
-
-"""
-    t8_element_MPI_Unpack(scheme, tree_class, recvbuf, buffer_size, position, elements, count, comm)
-
-### Prototype
-```c
-void t8_element_MPI_Unpack (const t8_scheme_c *scheme, const t8_eclass_t tree_class, void *recvbuf, const int buffer_size, int *position, t8_element_t **elements, const unsigned int count, sc_MPI_Comm comm);
-```
-"""
-function t8_element_MPI_Unpack(scheme, tree_class, recvbuf, buffer_size, position, elements, count, comm)
-    @ccall libt8.t8_element_MPI_Unpack(scheme::Ptr{t8_scheme_c}, tree_class::t8_eclass_t, recvbuf::Ptr{Cvoid}, buffer_size::Cint, position::Ptr{Cint}, elements::Ptr{Ptr{t8_element_t}}, count::Cuint, comm::MPI_Comm)::Cvoid
-end
-
-"""
-    t8_norm(vec)
-
-Vector norm.
-
-# Arguments
-* `vec`:\\[in\\] A 3D vector.
-# Returns
-The norm of *vec*.
-### Prototype
-```c
-double t8_norm (const double vec[3]);
-```
-"""
-function t8_norm(vec)
-    @ccall libt8.t8_norm(vec::Ptr{Cdouble})::Cdouble
-end
-
-"""
-    t8_normalize(vec)
-
-Normalize a vector.
-
-# Arguments
-* `vec`:\\[in,out\\] A 3D vector.
-### Prototype
-```c
-void t8_normalize (double vec[3]);
-```
-"""
-function t8_normalize(vec)
-    @ccall libt8.t8_normalize(vec::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_copy(dimensional_in, dimensional_out)
-
-Make a copy of a dimensional object.
-
-# Arguments
-* `dimensional_in`:\\[in\\]
-* `dimensional_out`:\\[out\\]
-### Prototype
-```c
-void t8_copy (const double dimensional_in[3], double dimensional_out[3]);
-```
-"""
-function t8_copy(dimensional_in, dimensional_out)
-    @ccall libt8.t8_copy(dimensional_in::Ptr{Cdouble}, dimensional_out::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_dist(vec_x, vec_y)
-
-Euclidean distance of X and Y.
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in\\] A 3D vector.
-# Returns
-The euclidean distance. Equivalent to norm (X-Y).
-### Prototype
-```c
-double t8_dist (const double vec_x[3], const double vec_y[3]);
-```
-"""
-function t8_dist(vec_x, vec_y)
-    @ccall libt8.t8_dist(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble})::Cdouble
-end
-
-"""
-    t8_ax(vec_x, alpha)
-
-Compute X = alpha * X
-
-# Arguments
-* `vec_x`:\\[in,out\\] A 3D vector. On output set to *alpha* * *vec_x*.
-* `alpha`:\\[in\\] A factor.
-### Prototype
-```c
-void t8_ax (double vec_x[3], const double alpha);
-```
-"""
-function t8_ax(vec_x, alpha)
-    @ccall libt8.t8_ax(vec_x::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
-end
-
-"""
-    t8_axy(vec_x, vec_y, alpha)
-
-Compute Y = alpha * X
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[out\\] On output set to *alpha* * *vec_x*.
-* `alpha`:\\[in\\] A factor.
-### Prototype
-```c
-void t8_axy (const double vec_x[3], double vec_y[3], const double alpha);
-```
-"""
-function t8_axy(vec_x, vec_y, alpha)
-    @ccall libt8.t8_axy(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
-end
-
-"""
-    t8_axb(vec_x, vec_y, alpha, b)
-
-Y = alpha * X + b
-
-!!! note
-
-    It is possible that vec\\_x = vec\\_y on input to overwrite x
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[out\\] On input, a 3D vector. On output set to *alpha* * *vec_x* + *b*.
-* `alpha`:\\[in\\] A factor.
-* `b`:\\[in\\] An offset.
-### Prototype
-```c
-void t8_axb (const double vec_x[3], double vec_y[3], const double alpha, const double b);
-```
-"""
-function t8_axb(vec_x, vec_y, alpha, b)
-    @ccall libt8.t8_axb(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble, b::Cdouble)::Cvoid
-end
-
-"""
-    t8_axpy(vec_x, vec_y, alpha)
-
-Y = Y + alpha * X
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in,out\\] On input, a 3D vector. On output set *to* vec\\_y + *alpha* * *vec_x*
-* `alpha`:\\[in\\] A factor.
-### Prototype
-```c
-void t8_axpy (const double vec_x[3], double vec_y[3], const double alpha);
-```
-"""
-function t8_axpy(vec_x, vec_y, alpha)
-    @ccall libt8.t8_axpy(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
-end
-
-"""
-    t8_axpyz(vec_x, vec_y, vec_z, alpha)
-
-Z = Y + alpha * X
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in\\] A 3D vector.
-* `vec_z`:\\[out\\] On output set *to* vec\\_y + *alpha* * *vec_x*
-* `alpha`:\\[in\\] A factor for the multiplication of *vec_x*.
-### Prototype
-```c
-void t8_axpyz (const double vec_x[3], const double vec_y[3], double vec_z[3], const double alpha);
-```
-"""
-function t8_axpyz(vec_x, vec_y, vec_z, alpha)
-    @ccall libt8.t8_axpyz(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, vec_z::Ptr{Cdouble}, alpha::Cdouble)::Cvoid
-end
-
-"""
-    t8_dot(vec_x, vec_y)
-
-Dot product of X and Y.
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in\\] A 3D vector.
-# Returns
-The dot product *vec_x* * *vec_y*
-### Prototype
-```c
-double t8_dot (const double vec_x[3], const double vec_y[3]);
-```
-"""
-function t8_dot(vec_x, vec_y)
-    @ccall libt8.t8_dot(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble})::Cdouble
-end
-
-"""
-    t8_cross_3D(vec_x, vec_y, cross)
-
-Cross product of X and Y
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in\\] A 3D vector.
-* `cross`:\\[out\\] On output, the cross product of *vec_x* and *vec_y*.
-### Prototype
-```c
-void t8_cross_3D (const double vec_x[3], const double vec_y[3], double cross[3]);
-```
-"""
-function t8_cross_3D(vec_x, vec_y, cross)
-    @ccall libt8.t8_cross_3D(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, cross::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_cross_2D(vec_x, vec_y)
-
-Cross product of X and Y
-
-# Arguments
-* `vec_x`:\\[in\\] A 2D vector.
-* `vec_y`:\\[in\\] A 2D vector.
-# Returns
-The cross product of *vec_x* and *vec_y*.
-### Prototype
-```c
-double t8_cross_2D (const double vec_x[2], const double vec_y[2]);
-```
-"""
-function t8_cross_2D(vec_x, vec_y)
-    @ccall libt8.t8_cross_2D(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble})::Cdouble
-end
-
-"""
-    t8_diff(vec_x, vec_y, diff)
-
-Compute the difference of two vectors.
-
-# Arguments
-* `vec_x`:\\[in\\] A 3D vector.
-* `vec_y`:\\[in\\] A 3D vector.
-* `diff`:\\[out\\] On output, the difference of *vec_x* and *vec_y*.
-### Prototype
-```c
-void t8_diff (const double vec_x[3], const double vec_y[3], double diff[3]);
-```
-"""
-function t8_diff(vec_x, vec_y, diff)
-    @ccall libt8.t8_diff(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, diff::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_eq(vec_x, vec_y, tol)
-
-Check the equality of two vectors elementwise
-
-# Arguments
-* `vec_x`:\\[in\\]
-* `vec_y`:\\[in\\]
-* `tol`:\\[in\\]
-# Returns
-true, if the vectors are equal up to *tol*
-### Prototype
-```c
-int t8_eq (const double vec_x[3], const double vec_y[3], const double tol);
-```
-"""
-function t8_eq(vec_x, vec_y, tol)
-    @ccall libt8.t8_eq(vec_x::Ptr{Cdouble}, vec_y::Ptr{Cdouble}, tol::Cdouble)::Cint
-end
-
-"""
-    t8_rescale(vec, new_length)
-
-Rescale a vector to a new length.
-
-# Arguments
-* `vec`:\\[in,out\\] A 3D vector.
-* `new_length`:\\[in\\] New length of the vector.
-### Prototype
-```c
-void t8_rescale (double vec[3], const double new_length);
-```
-"""
-function t8_rescale(vec, new_length)
-    @ccall libt8.t8_rescale(vec::Ptr{Cdouble}, new_length::Cdouble)::Cvoid
-end
-
-"""
-    t8_normal_of_tri(p1, p2, p3, normal)
-
-Compute the normal of a triangle given by its three vertices.
-
-# Arguments
-* `p1`:\\[in\\] A 3D vector.
-* `p2`:\\[in\\] A 3D vector.
-* `p3`:\\[in\\] A 3D vector.
-* `normal`:\\[out\\] vector of the triangle. (Not necessarily of length 1!)
-### Prototype
-```c
-void t8_normal_of_tri (const double p1[3], const double p2[3], const double p3[3], double normal[3]);
-```
-"""
-function t8_normal_of_tri(p1, p2, p3, normal)
-    @ccall libt8.t8_normal_of_tri(p1::Ptr{Cdouble}, p2::Ptr{Cdouble}, p3::Ptr{Cdouble}, normal::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_orthogonal_tripod(v1, v2, v3)
-
-Compute an orthogonal coordinate system from a given vector.
-
-# Arguments
-* `v1`:\\[in\\] 3D vector.
-* `v2`:\\[out\\] 3D vector.
-* `v3`:\\[out\\] 3D vector.
-### Prototype
-```c
-void t8_orthogonal_tripod (const double v1[3], double v2[3], double v3[3]);
-```
-"""
-function t8_orthogonal_tripod(v1, v2, v3)
-    @ccall libt8.t8_orthogonal_tripod(v1::Ptr{Cdouble}, v2::Ptr{Cdouble}, v3::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_swap(p1, p2)
-
-Swap the components of two vectors.
-
-# Arguments
-* `p1`:\\[in,out\\] A 3D vector.
-* `p2`:\\[in,out\\] A 3D vector.
-### Prototype
-```c
-void t8_swap (double p1[3], double p2[3]);
-```
-"""
-function t8_swap(p1, p2)
-    @ccall libt8.t8_swap(p1::Ptr{Cdouble}, p2::Ptr{Cdouble})::Cvoid
-end
-
-"""
-    t8_write_pvtu(filename, num_procs, write_tree, write_rank, write_level, write_id, num_data, data)
-
-Writes the pvtu header file that links to the processor local files. It is used by the cmesh and forest vtk routines. This function should only be called by one process. Return 0 on success.
-
-### Prototype
-```c
-int t8_write_pvtu (const char *filename, int num_procs, int write_tree, int write_rank, int write_level, int write_id, int num_data, t8_vtk_data_field_t *data);
-```
-"""
-function t8_write_pvtu(filename, num_procs, write_tree, write_rank, write_level, write_id, num_data, data)
-    @ccall libt8.t8_write_pvtu(filename::Cstring, num_procs::Cint, write_tree::Cint, write_rank::Cint, write_level::Cint, write_id::Cint, num_data::Cint, data::Ptr{t8_vtk_data_field_t})::Cint
-end
-
-"""
     vtk_file_type
 
 Enumerator for all types of files readable by t8code.
-
-| Enumerator                           | Note                                           |
-| :----------------------------------- | :--------------------------------------------- |
-| VTK\\_FILE\\_ERROR                   | For Testing purpose.                           |
-| VTK\\_SERIAL\\_FILE                  | VTK file type of serial files.                 |
-| VTK\\_UNSTRUCTURED\\_FILE            | Unstructured file type is the same as serial.  |
-| VTK\\_POLYDATA\\_FILE                | VTK polydata file type.                        |
-| VTK\\_PARALLEL\\_FILE                | VTK file type of parallel files.               |
-| VTK\\_PARALLEL\\_UNSTRUCTURED\\_FILE | For parallel unstructured files.               |
-| VTK\\_PARALLEL\\_POLYDATA\\_FILE     | VTK polydata parallel file type.               |
-| VTK\\_NUM\\_TYPES                    | Number of different vtk file types supported.  |
 """
 @cenum vtk_file_type::Int32 begin
     VTK_FILE_ERROR = -1
@@ -15601,28 +17607,17 @@ end
 """Enumerator for all types of files readable by t8code."""
 const vtk_file_type_t = vtk_file_type
 
-"""
-    vtk_read_success
-
-Enumerator for the success of reading a vtk file. This is used to indicate whether the reading was successful or not.
-
-| Enumerator     | Note                                             |
-| :------------- | :----------------------------------------------- |
-| read\\_failure | Indicates that file reading was not successful.  |
-| read\\_success | Indicates that file reading was successful.      |
-"""
 @cenum vtk_read_success::UInt32 begin
     read_failure = 0
     read_success = 1
 end
 
-"""Enumerator for the success of reading a vtk file. This is used to indicate whether the reading was successful or not."""
 const vtk_read_success_t = vtk_read_success
 
 """
     t8_forest_vtk_write_file_via_API(forest, fileprefix, write_treeid, write_mpirank, write_level, write_element_id, curved_flag, write_ghosts, num_data, data)
 
-Write the forest in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function uses the vtk library. t8code must be configured with "-DT8CODE\\_ENABLE\\_VTK=ON" in order to use it. Currently does not support pyramid elements.
+Write the forest in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function uses the vtk library. t8code must be configured with "--with-vtk" in order to use it. Currently does not support pyramid elements.
 
 !!! note
 
@@ -15653,7 +17648,7 @@ end
 """
     t8_forest_vtk_write_file(forest, fileprefix, write_treeid, write_mpirank, write_level, write_element_id, write_ghosts, num_data, data)
 
-Write the forest in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function writes ASCII files and can be used when t8code is not configured with "-DT8CODE\\_ENABLE\\_VTK=ON" and t8_forest_vtk_write_file_via_API is not available.
+Write the forest in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function writes ASCII files and can be used when t8code is not configure with "--with-vtk" and t8_forest_vtk_write_file_via_API is not available.
 
 # Arguments
 * `forest`:\\[in\\] The forest.
@@ -15691,13 +17686,13 @@ end
 """
     t8_cmesh_vtk_write_file(cmesh, fileprefix)
 
-Write the cmesh in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function writes ASCII files and can be used when t8code is not configured with "-DT8CODE\\_ENABLE\\_VTK=ON" and t8_cmesh_vtk_write_file_via_API is not available.
+Write the cmesh in .pvtu file format. Writes one .vtu file per process and a meta .pvtu file. This function writes ASCII files and can be used when t8code is not configure with "--with-vtk" and t8_cmesh_vtk_write_file_via_API is not available.
 
 # Arguments
 * `cmesh`:\\[in\\] The cmesh
 * `fileprefix`:\\[in\\] The prefix of the output files
 # Returns
-True (nonzero) if successful, false (zero) otherwise
+int
 ### Prototype
 ```c
 int t8_cmesh_vtk_write_file (t8_cmesh_t cmesh, const char *fileprefix);
@@ -15707,1074 +17702,12 @@ function t8_cmesh_vtk_write_file(cmesh, fileprefix)
     @ccall libt8.t8_cmesh_vtk_write_file(cmesh::t8_cmesh_t, fileprefix::Cstring)::Cint
 end
 
-"""
-    t8_cmesh_from_msh_file(fileprefix, partition, comm, dim, master, use_cad_geometry)
-
-### Prototype
-```c
-t8_cmesh_t t8_cmesh_from_msh_file (const char *fileprefix, int partition, sc_MPI_Comm comm, int dim, int master, int use_cad_geometry);
-```
-"""
-function t8_cmesh_from_msh_file(fileprefix, partition, comm, dim, master, use_cad_geometry)
-    @ccall libt8.t8_cmesh_from_msh_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, dim::Cint, master::Cint, use_cad_geometry::Cint)::t8_cmesh_t
-end
-
-struct sc_flopinfo
-    seconds::Cdouble
-    cwtime::Cdouble
-    crtime::Cfloat
-    cptime::Cfloat
-    cflpops::Clonglong
-    iwtime::Cdouble
-    irtime::Cfloat
-    iptime::Cfloat
-    iflpops::Clonglong
-    mflops::Cfloat
-    use_papi::Cint
-end
-
-const sc_flopinfo_t = sc_flopinfo
-
-"""
-    sc_flops_snap(fi, snapshot)
-
-Call [`sc_flops_count`](@ref) (fi) and copies fi into snapshot.
-
-# Arguments
-* `fi`:\\[in,out\\] Members will be updated.
-* `snapshot`:\\[out\\] On output is a copy of fi.
-### Prototype
-```c
-void sc_flops_snap (sc_flopinfo_t * fi, sc_flopinfo_t * snapshot);
-```
-"""
-function sc_flops_snap(fi, snapshot)
-    @ccall libsc.sc_flops_snap(fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t})::Cvoid
-end
-
-"""
-    sc_flops_shot(fi, snapshot)
-
-Call [`sc_flops_count`](@ref) (fi) and override snapshot interval timings with the differences since the previous call to [`sc_flops_snap`](@ref). The interval mflop rate is computed by iflpops / 1e6 / irtime. The cumulative timings in snapshot are copied form fi.
-
-# Arguments
-* `fi`:\\[in,out\\] Members will be updated.
-* `snapshot`:\\[in,out\\] Interval timings measured since [`sc_flops_snap`](@ref).
-### Prototype
-```c
-void sc_flops_shot (sc_flopinfo_t * fi, sc_flopinfo_t * snapshot);
-```
-"""
-function sc_flops_shot(fi, snapshot)
-    @ccall libsc.sc_flops_shot(fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t})::Cvoid
-end
-
-"""
-    sc_flops_papi(rtime, ptime, flpops, mflops)
-
-Calls PAPI\\_flops. Aborts on PAPI error. The first call sets up the performance counters. Subsequent calls return cumulative real and process times, cumulative floating point operations and the flop rate since the last call. This is a compatibility wrapper: users should only need to use the [`sc_flopinfo_t`](@ref) interface functions below.
-
-### Prototype
-```c
-void sc_flops_papi (float *rtime, float *ptime, long long *flpops, float *mflops);
-```
-"""
-function sc_flops_papi(rtime, ptime, flpops, mflops)
-    @ccall libsc.sc_flops_papi(rtime::Ptr{Cfloat}, ptime::Ptr{Cfloat}, flpops::Ptr{Clonglong}, mflops::Ptr{Cfloat})::Cvoid
-end
-
-"""
-    sc_flops_start(fi)
-
-Prepare [`sc_flopinfo_t`](@ref) structure and start flop counters. Must only be called once during the program run. This function calls [`sc_flops_papi`](@ref).
-
-# Arguments
-* `fi`:\\[out\\] Members will be initialized.
-### Prototype
-```c
-void sc_flops_start (sc_flopinfo_t * fi);
-```
-"""
-function sc_flops_start(fi)
-    @ccall libsc.sc_flops_start(fi::Ptr{sc_flopinfo_t})::Cvoid
-end
-
-"""
-    sc_flops_start_nopapi(fi)
-
-Prepare [`sc_flopinfo_t`](@ref) structure and ignore the flop counters. This [`sc_flopinfo_t`](@ref) does not call PAPI\\_flops() in this function or in [`sc_flops_count`](@ref)().
-
-# Arguments
-* `fi`:\\[out\\] Members will be initialized.
-### Prototype
-```c
-void sc_flops_start_nopapi (sc_flopinfo_t * fi);
-```
-"""
-function sc_flops_start_nopapi(fi)
-    @ccall libsc.sc_flops_start_nopapi(fi::Ptr{sc_flopinfo_t})::Cvoid
-end
-
-"""
-    sc_flops_count(fi)
-
-Update [`sc_flopinfo_t`](@ref) structure with current measurement. Must only be called after [`sc_flops_start`](@ref). Can be called any number of times. This function calls [`sc_flops_papi`](@ref).
-
-# Arguments
-* `fi`:\\[in,out\\] Members will be updated.
-### Prototype
-```c
-void sc_flops_count (sc_flopinfo_t * fi);
-```
-"""
-function sc_flops_count(fi)
-    @ccall libsc.sc_flops_count(fi::Ptr{sc_flopinfo_t})::Cvoid
-end
-
-# automatic type deduction for variadic arguments may not be what you want, please use with caution
-@generated function sc_flops_shotv(fi, va_list...)
-        :(@ccall(libsc.sc_flops_shotv(fi::Ptr{sc_flopinfo_t}; $(to_c_type_pairs(va_list)...))::Cvoid))
-    end
-
-mutable struct sc_options end
-
-"""The options data structure is opaque."""
-const sc_options_t = sc_options
-
-# typedef int ( * sc_options_callback_t ) ( sc_options_t * opt , const char * opt_arg , void * data )
-"""
-This callback can be invoked with sc_options_parse.
-
-# Arguments
-* `opt`:\\[in\\] Valid options data structure. This is passed as a matter of principle.
-* `opt_arg`:\\[in\\] The option argument or NULL if there is none. This variable is internal. Do not store pointer.
-* `data`:\\[in\\] User-defined data passed to [`sc_options_add_callback`](@ref).
-# Returns
-Return 0 if successful, -1 to indicate a parse error.
-"""
-const sc_options_callback_t = Ptr{Cvoid}
-
-"""
-    sc_options_new(program_path)
-
-Create an empty options structure.
-
-# Arguments
-* `program_path`:\\[in\\] Name or path name of the program to display. Usually argv[0] is fine.
-# Returns
-A valid and empty options structure.
-### Prototype
-```c
-sc_options_t *sc_options_new (const char *program_path);
-```
-"""
-function sc_options_new(program_path)
-    @ccall libsc.sc_options_new(program_path::Cstring)::Ptr{sc_options_t}
-end
-
-"""
-    sc_options_destroy_deep(opt)
-
-Destroy the options structure and all allocated structures contained. The keyvalue structure passed into sc\\_keyvalue\\_add is destroyed.
-
-!!! compat "Deprecated"
-
-    This function is kept for backwards compatibility. It is best to destroy any key-value container outside of the lifetime of the options object.
-
-# Arguments
-* `opt`:\\[in,out\\] This options structure is deallocated, including all key-value containers referenced.
-### Prototype
-```c
-void sc_options_destroy_deep (sc_options_t * opt);
-```
-"""
-function sc_options_destroy_deep(opt)
-    @ccall libsc.sc_options_destroy_deep(opt::Ptr{sc_options_t})::Cvoid
-end
-
-"""
-    sc_options_destroy(opt)
-
-Destroy the options structure. Whatever has been passed into sc\\_keyvalue\\_add is left alone.
-
-# Arguments
-* `opt`:\\[in,out\\] This options structure is deallocated.
-### Prototype
-```c
-void sc_options_destroy (sc_options_t * opt);
-```
-"""
-function sc_options_destroy(opt)
-    @ccall libsc.sc_options_destroy(opt::Ptr{sc_options_t})::Cvoid
-end
-
-"""
-    sc_options_set_spacing(opt, space_type, space_help)
-
-Set the spacing for sc_options_print_summary. There are two values to be set: the spacing from the beginning of the printed line to the type of the option variable, and from the beginning of the printed line to the help string.
-
-# Arguments
-* `opt`:\\[in,out\\] Valid options structure.
-* `space_type`:\\[in\\] Number of spaces to the type display, for example <INT>, <STRING>, etc. Setting this negative sets the default 20.
-* `space_help`:\\[in\\] Number of space to the help string. Setting this negative sets the default 32.
-### Prototype
-```c
-void sc_options_set_spacing (sc_options_t * opt, int space_type, int space_help);
-```
-"""
-function sc_options_set_spacing(opt, space_type, space_help)
-    @ccall libsc.sc_options_set_spacing(opt::Ptr{sc_options_t}, space_type::Cint, space_help::Cint)::Cvoid
-end
-
-"""
-    sc_options_add_switch(opt, opt_char, opt_name, variable, help_string)
-
-Add a switch option. This option is used without option arguments. Every use increments the variable by one. Its initial value is 0. Either opt\\_char or opt\\_name must be valid, that is, not '\\0'/NULL.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_switch (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, const char *help_string);
-```
-"""
-function sc_options_add_switch(opt, opt_char, opt_name, variable, help_string)
-    @ccall libsc.sc_options_add_switch(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_bool(opt, opt_char, opt_name, variable, init_value, help_string)
-
-Add a boolean option. It can be initialized to true or false in the C sense. Specifying it on the command line without argument sets the option to true. The argument 0/f/F/n/N sets it to false (0). The argument 1/t/T/y/Y sets it to true (nonzero).
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `init_value`:\\[in\\] Initial value to set the option, read as true or false.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_bool (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, int init_value, const char *help_string);
-```
-"""
-function sc_options_add_bool(opt, opt_char, opt_name, variable, init_value, help_string)
-    @ccall libsc.sc_options_add_bool(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, init_value::Cint, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_int(opt, opt_char, opt_name, variable, init_value, help_string)
-
-Add an option that takes an integer argument.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `init_value`:\\[in\\] The initial value of the option variable.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_int (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, int init_value, const char *help_string);
-```
-"""
-function sc_options_add_int(opt, opt_char, opt_name, variable, init_value, help_string)
-    @ccall libsc.sc_options_add_int(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, init_value::Cint, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_size_t(opt, opt_char, opt_name, variable, init_value, help_string)
-
-Add an option that takes a size\\_t argument. The value of the size\\_t variable must not be greater than LLONG\\_MAX.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `init_value`:\\[in\\] The initial value of the option variable.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_size_t (sc_options_t * opt, int opt_char, const char *opt_name, size_t *variable, size_t init_value, const char *help_string);
-```
-"""
-function sc_options_add_size_t(opt, opt_char, opt_name, variable, init_value, help_string)
-    @ccall libsc.sc_options_add_size_t(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Csize_t}, init_value::Csize_t, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_double(opt, opt_char, opt_name, variable, init_value, help_string)
-
-Add an option that takes a double argument. The double must be in the legal range. "inf" and "nan" are legal too.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `init_value`:\\[in\\] The initial value of the option variable.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_double (sc_options_t * opt, int opt_char, const char *opt_name, double *variable, double init_value, const char *help_string);
-```
-"""
-function sc_options_add_double(opt, opt_char, opt_name, variable, init_value, help_string)
-    @ccall libsc.sc_options_add_double(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cdouble}, init_value::Cdouble, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_string(opt, opt_char, opt_name, variable, init_value, help_string)
-
-Add a string option.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `variable`:\\[in\\] Address of the variable to store the option value.
-* `init_value`:\\[in\\] This default value of the option may be NULL. If not NULL, the value is copied to internal storage.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_string (sc_options_t * opt, int opt_char, const char *opt_name, const char **variable, const char *init_value, const char *help_string);
-```
-"""
-function sc_options_add_string(opt, opt_char, opt_name, variable, init_value, help_string)
-    @ccall libsc.sc_options_add_string(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cstring}, init_value::Cstring, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_inifile(opt, opt_char, opt_name, help_string)
-
-Add an option to read in a file in `.ini` format. The argument to this option must be a filename. On parsing the specified file is read to set known option variables. It does not have an associated option variable itself.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_inifile (sc_options_t * opt, int opt_char, const char *opt_name, const char *help_string);
-```
-"""
-function sc_options_add_inifile(opt, opt_char, opt_name, help_string)
-    @ccall libsc.sc_options_add_inifile(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_jsonfile(opt, opt_char, opt_name, help_string)
-
-Add an option to read in a file in JSON format. The argument to this option must be a filename. On parsing the specified file is read to set known option variables. It does not have an associated option variable itself.
-
-This functionality is only active when sc_have_json returns true, equivalent to the define SC\\_HAVE\\_JSON existing, and ignored otherwise.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_jsonfile (sc_options_t * opt, int opt_char, const char *opt_name, const char *help_string);
-```
-"""
-function sc_options_add_jsonfile(opt, opt_char, opt_name, help_string)
-    @ccall libsc.sc_options_add_jsonfile(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_callback(opt, opt_char, opt_name, has_arg, fn, data, help_string)
-
-Add an option that calls a user-defined function when parsed. The callback function should be implemented to allow multiple calls. The callback may be used to set multiple option variables in bulk that would otherwise require an inconvenient number of individual options. This option is not loaded from or saved to files.
-
-# Arguments
-* `opt`:\\[in,out\\] A valid options structure.
-* `opt_char`:\\[in\\] Short option character, may be '\\0'.
-* `opt_name`:\\[in\\] Long option name without initial dashes, may be NULL.
-* `has_arg`:\\[in\\] Specify whether the option needs an option argument. This can be 0 for none, 1 for a required argument, and 2 for an optional argument; see getopt\\_long (3).
-* `fn`:\\[in\\] Function to call when this option is encountered.
-* `data`:\\[in\\] User-defined data passed to the callback.
-* `help_string`:\\[in\\] Help string for usage message, may be NULL.
-### Prototype
-```c
-void sc_options_add_callback (sc_options_t * opt, int opt_char, const char *opt_name, int has_arg, sc_options_callback_t fn, void *data, const char *help_string);
-```
-"""
-function sc_options_add_callback(opt, opt_char, opt_name, has_arg, fn, data, help_string)
-    @ccall libsc.sc_options_add_callback(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, has_arg::Cint, fn::sc_options_callback_t, data::Ptr{Cvoid}, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_keyvalue(opt, opt_char, opt_name, variable, init_value, keyvalue, help_string)
-
-Add an option that takes string keys into a lookup table of integers. On calling this function, it must be certain that the initial value exists.
-
-# Arguments
-* `opt`:\\[in\\] Initialized options structure.
-* `opt_char`:\\[in\\] Option character for command line, or 0.
-* `opt_name`:\\[in\\] Name of the long option, or NULL.
-* `variable`:\\[in\\] Address of an existing integer that holds the value of this option parameter.
-* `init_value`:\\[in\\] The key that is looked up for the initial value. It must be certain that the key exists and its value is of type integer.
-* `keyvalue`:\\[in\\] A valid key-value structure where the values must be integers. If a key is asked for that does not exist, we will produce an option error. This structure must stay alive as long as opt.
-* `help_string`:\\[in\\] Instructive one-line string to explain the option.
-### Prototype
-```c
-void sc_options_add_keyvalue (sc_options_t * opt, int opt_char, const char *opt_name, int *variable, const char *init_value, sc_keyvalue_t * keyvalue, const char *help_string);
-```
-"""
-function sc_options_add_keyvalue(opt, opt_char, opt_name, variable, init_value, keyvalue, help_string)
-    @ccall libsc.sc_options_add_keyvalue(opt::Ptr{sc_options_t}, opt_char::Cint, opt_name::Cstring, variable::Ptr{Cint}, init_value::Cstring, keyvalue::Ptr{sc_keyvalue_t}, help_string::Cstring)::Cvoid
-end
-
-"""
-    sc_options_add_suboptions(opt, subopt, prefix)
-
-Copy one set of options to another as a subset, with a prefix. The variables referenced by the options and the suboptions are the same.
-
-# Arguments
-* `opt`:\\[in,out\\] A set of options.
-* `subopt`:\\[in\\] Another set of options to be copied.
-* `prefix`:\\[in\\] The prefix to add to option names as they are copied. If an option has a long name "name" in subopt, its name in opt is "prefix:name"; if an option only has a character 'c' in subopt, its name in opt is "prefix:-c".
-### Prototype
-```c
-void sc_options_add_suboptions (sc_options_t * opt, sc_options_t * subopt, const char *prefix);
-```
-"""
-function sc_options_add_suboptions(opt, subopt, prefix)
-    @ccall libsc.sc_options_add_suboptions(opt::Ptr{sc_options_t}, subopt::Ptr{sc_options_t}, prefix::Cstring)::Cvoid
-end
-
-"""
-    sc_options_print_usage(package_id, log_priority, opt, arg_usage)
-
-Print a usage message. This function uses the [`SC_LC_GLOBAL`](@ref) log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `log_priority`:\\[in\\] Priority for output according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `arg_usage`:\\[in\\] If not NULL, an <ARGUMENTS> string is appended to the usage line. If the string is non-empty, it will be printed after the option summary and an "ARGUMENTS:\\n" title line. Line breaks are identified by strtok(3) and honored.
-### Prototype
-```c
-void sc_options_print_usage (int package_id, int log_priority, sc_options_t * opt, const char *arg_usage);
-```
-"""
-function sc_options_print_usage(package_id, log_priority, opt, arg_usage)
-    @ccall libsc.sc_options_print_usage(package_id::Cint, log_priority::Cint, opt::Ptr{sc_options_t}, arg_usage::Cstring)::Cvoid
-end
-
-"""
-    sc_options_print_summary(package_id, log_priority, opt)
-
-Print a summary of all option values. Prints the title "Options:" and a line for every option, then the title "Arguments:" and a line for every argument. This function uses the [`SC_LC_GLOBAL`](@ref) log category. That means the default action is to print only on rank 0. Applications can change that by providing a user-defined log handler.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `log_priority`:\\[in\\] Priority for output according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-### Prototype
-```c
-void sc_options_print_summary (int package_id, int log_priority, sc_options_t * opt);
-```
-"""
-function sc_options_print_summary(package_id, log_priority, opt)
-    @ccall libsc.sc_options_print_summary(package_id::Cint, log_priority::Cint, opt::Ptr{sc_options_t})::Cvoid
-end
-
-"""
-    sc_options_load(package_id, err_priority, opt, file)
-
-Load a file in the default format and update option values. The default is a file in the `.ini` format; see sc_options_load_ini.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `file`:\\[in\\] Filename of the file to load.
-# Returns
-Returns 0 on success, -1 on failure.
-### Prototype
-```c
-int sc_options_load (int package_id, int err_priority, sc_options_t * opt, const char *file);
-```
-"""
-function sc_options_load(package_id, err_priority, opt, file)
-    @ccall libsc.sc_options_load(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, file::Cstring)::Cint
-end
-
-"""
-    sc_options_load_ini(package_id, err_priority, opt, inifile, re)
-
-Load a file in `.ini` format and update entries found under [Options]. An option whose name contains a colon such as "prefix:basename" will be updated by a "basename =" entry in a [prefix] section.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `inifile`:\\[in\\] Filename of the ini file to load.
-* `re`:\\[in,out\\] Provisioned for runtime error checking implementation; currently must be NULL.
-# Returns
-Returns 0 on success, -1 on failure.
-### Prototype
-```c
-int sc_options_load_ini (int package_id, int err_priority, sc_options_t * opt, const char *inifile, void *re);
-```
-"""
-function sc_options_load_ini(package_id, err_priority, opt, inifile, re)
-    @ccall libsc.sc_options_load_ini(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring, re::Ptr{Cvoid})::Cint
-end
-
-"""
-    sc_options_load_json(package_id, err_priority, opt, jsonfile, re)
-
-Load a file in JSON format and update entries from object "Options". An option whose name contains a colon such as "Prefix:basename" will be updated by a "basename :" entry in a "Prefix" nested object.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `jsonfile`:\\[in\\] Filename of the JSON file to load.
-* `re`:\\[in,out\\] Provisioned for runtime error checking implementation; currently must be NULL.
-# Returns
-Returns 0 on success, -1 on failure.
-### Prototype
-```c
-int sc_options_load_json (int package_id, int err_priority, sc_options_t * opt, const char *jsonfile, void *re);
-```
-"""
-function sc_options_load_json(package_id, err_priority, opt, jsonfile, re)
-    @ccall libsc.sc_options_load_json(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, jsonfile::Cstring, re::Ptr{Cvoid})::Cint
-end
-
-"""
-    sc_options_save(package_id, err_priority, opt, inifile)
-
-Save all options and arguments to a file in `.ini` format. This function must only be called after successful option parsing. This function should only be called on rank 0. This function will log errors with category [`SC_LC_GLOBAL`](@ref). An options whose name contains a colon such as "Prefix:basename" will be written in a section titled [Prefix] as "basename =".
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `inifile`:\\[in\\] Filename of the ini file to save.
-# Returns
-Returns 0 on success, -1 on failure.
-### Prototype
-```c
-int sc_options_save (int package_id, int err_priority, sc_options_t * opt, const char *inifile);
-```
-"""
-function sc_options_save(package_id, err_priority, opt, inifile)
-    @ccall libsc.sc_options_save(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring)::Cint
-end
-
-"""
-    sc_options_load_args(package_id, err_priority, opt, inifile)
-
-Load a file in `.ini` format and update entries found under [Arguments]. There needs to be a key Arguments.count specifying the number. Then as many integer keys starting with 0 need to be present.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The args are stored in this option structure.
-* `inifile`:\\[in\\] Filename of the ini file to load.
-# Returns
-Returns 0 on success, -1 on failure.
-### Prototype
-```c
-int sc_options_load_args (int package_id, int err_priority, sc_options_t * opt, const char *inifile);
-```
-"""
-function sc_options_load_args(package_id, err_priority, opt, inifile)
-    @ccall libsc.sc_options_load_args(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, inifile::Cstring)::Cint
-end
-
-"""
-    sc_options_parse(package_id, err_priority, opt, argc, argv)
-
-Parse command line options.
-
-# Arguments
-* `package_id`:\\[in\\] Registered package id or -1.
-* `err_priority`:\\[in\\] Error priority according to sc_logprios.
-* `opt`:\\[in\\] The option structure.
-* `argc`:\\[in\\] Length of argument list.
-* `argv`:\\[in,out\\] Argument list may be permuted.
-# Returns
-Returns -1 on an invalid option, otherwise the position of the first non-option argument.
-### Prototype
-```c
-int sc_options_parse (int package_id, int err_priority, sc_options_t * opt, int argc, char **argv);
-```
-"""
-function sc_options_parse(package_id, err_priority, opt, argc, argv)
-    @ccall libsc.sc_options_parse(package_id::Cint, err_priority::Cint, opt::Ptr{sc_options_t}, argc::Cint, argv::Ptr{Cstring})::Cint
-end
-
-"""
-    t8_cmesh_from_tetgen_file(fileprefix, partition, comm, do_dup)
-
-### Prototype
-```c
-t8_cmesh_t t8_cmesh_from_tetgen_file (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup);
-```
-"""
-function t8_cmesh_from_tetgen_file(fileprefix, partition, comm, do_dup)
-    @ccall libt8.t8_cmesh_from_tetgen_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint)::t8_cmesh_t
-end
-
-"""
-    t8_cmesh_from_tetgen_file_time(fileprefix, partition, comm, do_dup, fi, snapshot, stats, statentry)
-
-### Prototype
-```c
-t8_cmesh_t t8_cmesh_from_tetgen_file_time (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup, sc_flopinfo_t *fi, sc_flopinfo_t *snapshot, sc_statinfo_t *stats, int statentry);
-```
-"""
-function t8_cmesh_from_tetgen_file_time(fileprefix, partition, comm, do_dup, fi, snapshot, stats, statentry)
-    @ccall libt8.t8_cmesh_from_tetgen_file_time(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint, fi::Ptr{sc_flopinfo_t}, snapshot::Ptr{sc_flopinfo_t}, stats::Ptr{sc_statinfo_t}, statentry::Cint)::t8_cmesh_t
-end
-
-"""
-    t8_cmesh_from_triangle_file(fileprefix, partition, comm, do_dup)
-
-### Prototype
-```c
-t8_cmesh_t t8_cmesh_from_triangle_file (char *fileprefix, int partition, sc_MPI_Comm comm, int do_dup);
-```
-"""
-function t8_cmesh_from_triangle_file(fileprefix, partition, comm, do_dup)
-    @ccall libt8.t8_cmesh_from_triangle_file(fileprefix::Cstring, partition::Cint, comm::MPI_Comm, do_dup::Cint)::t8_cmesh_t
-end
-
-mutable struct t8_cmesh_vertex_connectivity end
-
-"""
-[`t8_cmesh_vertex_connectivity_c`](@ref)
-
-Opaque pointer to the cmesh vertex connectivity structure.
-"""
-const t8_cmesh_vertex_connectivity_c = Ptr{t8_cmesh_vertex_connectivity}
-
-"""
-    t8_cmesh_set_global_vertices_of_tree(cmesh, global_tree, global_tree_vertices, num_vertices)
-
-### Prototype
-```c
-void t8_cmesh_set_global_vertices_of_tree (const t8_cmesh_t cmesh, const t8_gloidx_t global_tree, const t8_gloidx_t *global_tree_vertices, const int num_vertices);
-```
-"""
-function t8_cmesh_set_global_vertices_of_tree(cmesh, global_tree, global_tree_vertices, num_vertices)
-    @ccall libt8.t8_cmesh_set_global_vertices_of_tree(cmesh::Cint, global_tree::Cint, global_tree_vertices::Ptr{Cint}, num_vertices::Cint)::Cvoid
-end
-
-"""
-    t8_cmesh_get_num_global_vertices(cmesh)
-
-### Prototype
-```c
-t8_gloidx_t t8_cmesh_get_num_global_vertices (const t8_cmesh_t cmesh);
-```
-"""
-function t8_cmesh_get_num_global_vertices(cmesh)
-    @ccall libt8.t8_cmesh_get_num_global_vertices(cmesh::Cint)::Cint
-end
-
-"""
-    t8_cmesh_get_num_local_vertices(cmesh)
-
-### Prototype
-```c
-t8_locidx_t t8_cmesh_get_num_local_vertices (const t8_cmesh_t cmesh);
-```
-"""
-function t8_cmesh_get_num_local_vertices(cmesh)
-    @ccall libt8.t8_cmesh_get_num_local_vertices(cmesh::Cint)::Cint
-end
-
-"""
-    t8_cmesh_get_global_vertices_of_tree(cmesh, local_tree, num_vertices)
-
-### Prototype
-```c
-const t8_gloidx_t * t8_cmesh_get_global_vertices_of_tree (const t8_cmesh_t cmesh, const t8_locidx_t local_tree, int *num_vertices);
-```
-"""
-function t8_cmesh_get_global_vertices_of_tree(cmesh, local_tree, num_vertices)
-    @ccall libt8.t8_cmesh_get_global_vertices_of_tree(cmesh::Cint, local_tree::Cint, num_vertices::Ptr{Cint})::Ptr{Cint}
-end
-
-"""
-    t8_cmesh_get_global_vertex_of_tree(cmesh, local_tree, local_tree_vertex)
-
-### Prototype
-```c
-t8_gloidx_t t8_cmesh_get_global_vertex_of_tree (const t8_cmesh_t cmesh, const t8_locidx_t local_tree, const int local_tree_vertex);
-```
-"""
-function t8_cmesh_get_global_vertex_of_tree(cmesh, local_tree, local_tree_vertex)
-    @ccall libt8.t8_cmesh_get_global_vertex_of_tree(cmesh::Cint, local_tree::Cint, local_tree_vertex::Cint)::Cint
-end
-
-"""
-    t8_cmesh_get_num_trees_at_vertex(cmesh, global_vertex)
-
-### Prototype
-```c
-int t8_cmesh_get_num_trees_at_vertex (const t8_cmesh_t cmesh, t8_gloidx_t global_vertex);
-```
-"""
-function t8_cmesh_get_num_trees_at_vertex(cmesh, global_vertex)
-    @ccall libt8.t8_cmesh_get_num_trees_at_vertex(cmesh::Cint, global_vertex::Cint)::Cint
-end
-
-"""
-    t8_cmesh_uses_vertex_connectivity(cmesh)
-
-### Prototype
-```c
-int t8_cmesh_uses_vertex_connectivity (const t8_cmesh_t cmesh);
-```
-"""
-function t8_cmesh_uses_vertex_connectivity(cmesh)
-    @ccall libt8.t8_cmesh_uses_vertex_connectivity(cmesh::Cint)::Cint
-end
-
-# typedef int ( * t8_search_element_callback_c_wrapper ) ( t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int is_leaf , const t8_element_array_t * leaf_elements , const t8_locidx_t tree_leaf_index , void * user_data )
-"""
-A call-back function used by t8_forest_init_search for searching elements. Is called on an element and the search criterion should be checked on that element. Return true if the search criterion is met, false otherwise.
-
-# Arguments
-* `forest`:\\[in\\] the forest
-* `ltreeid`:\\[in\\] the local tree id of the current tree in the cmesh.
-* `element`:\\[in\\] the element for which the search criterion is checked
-* `is_leaf`:\\[in\\] true if and only if *element* is a leaf element
-* `leaf_elements`:\\[in\\] the leaf elements in *forest*
-* `tree_leaf_index`:\\[in\\] the local index of the first leaf in *leaf_elements*
-* `user_data`:\\[in\\] a user data pointer that can be set by the user
-# Returns
-non-zero if the search criterion is met, zero otherwise.
-"""
-const t8_search_element_callback_c_wrapper = Ptr{Cvoid}
-
-# typedef int ( * t8_search_queries_callback_c_wrapper ) ( t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int is_leaf , const t8_element_array_t * leaf_elements , const t8_locidx_t tree_leaf_index , void * queries , void * user_data )
-"""
-A call-back function used by t8_forest_init_search_with_queries for searching elements and executing queries. Is called on an element and all queries are checked on that element. All positive queries are passed further down to the children of the element up to leaf elements of the tree. The results of the check are stored in *query_matches*.
-
-# Arguments
-* `forest`:\\[in\\] the forest
-* `ltreeid`:\\[in\\] the local tree id of the current tree in the cmesh.
-* `element`:\\[in\\] the element for which the search criterion is checked
-* `is_leaf`:\\[in\\] true if and only if *element* is a leaf element
-* `leaf_elements`:\\[in\\] the leaf elements in *forest*
-* `tree_leaf_index`:\\[in\\] the local index of the first leaf in *leaf_elements*
-* `queries`:\\[in\\] a pointer to an array of queries
-* `user_data`:\\[in\\] a user data pointer that can be set by the user
-"""
-const t8_search_queries_callback_c_wrapper = Ptr{Cvoid}
-
-# typedef void ( * t8_search_batched_queries_callback_c_wrapper ) ( t8_forest_t forest , const t8_locidx_t ltreeid , const t8_element_t * element , const int is_leaf , const t8_element_array_t * leaf_elements , const t8_locidx_t tree_leaf_index , const void * queries , const size_t * active_query_indices , int * query_matches , void * user_data )
-"""
-A call-back function used by t8_forest_init_search_with_batched_queries for searching elements and executing batched queries. Is called on an element and all queries are checked on that element. All positive queries are passed further down to the children of the element up to leaf elements of the tree. The results of the check are stored in *query_matches*.
-
-# Arguments
-* `forest`:\\[in\\] the forest
-* `ltreeid`:\\[in\\] the local tree id of the current tree in the cmesh.
-* `element`:\\[in\\] the element for which the search criterion is checked
-* `is_leaf`:\\[in\\] true if and only if *element* is a leaf element
-* `leaf_elements`:\\[in\\] the leaf elements in *forest*
-* `tree_leaf_index`:\\[in\\] the local index of the first leaf in *leaf_elements*
-* `queries`:\\[in\\] a pointer to an array of queries
-* `active_query_indices`:\\[in\\] a pointer to an array of indices of active queries in *queries*
-* `query_matches`:\\[in,out\\] a pointer to an array of length *num_active_queries*. If query\\_matches[i] is true, then the element 'matches' the query of the active query with index active\\_query\\_indices[i].
-* `user_data`:\\[in\\] a user data pointer that can be set by the user
-"""
-const t8_search_batched_queries_callback_c_wrapper = Ptr{Cvoid}
-
-mutable struct t8_forest_c_search end
-
-"""A wrapper around the forest search context"""
-const t8_forest_search_c_wrapper = Ptr{t8_forest_c_search}
-
-"""
-    t8_forest_init_search(search, element_callback, forest)
-
-### Prototype
-```c
-void t8_forest_init_search (t8_forest_search_c_wrapper search, t8_search_element_callback_c_wrapper element_callback, const t8_forest_t forest);
-```
-"""
-function t8_forest_init_search(search, element_callback, forest)
-    @ccall libt8.t8_forest_init_search(search::t8_forest_search_c_wrapper, element_callback::t8_search_element_callback_c_wrapper, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_update_forest(search, forest)
-
-### Prototype
-```c
-void t8_forest_search_update_forest (t8_forest_search_c_wrapper search, const t8_forest_t forest);
-```
-"""
-function t8_forest_search_update_forest(search, forest)
-    @ccall libt8.t8_forest_search_update_forest(search::t8_forest_search_c_wrapper, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_update_user_data(search, udata)
-
-Update the user data pointer in the search context
-
-# Arguments
-* `search`:\\[in,out\\] the search context to update
-* `udata`:\\[in\\] the new user data pointer to use
-### Prototype
-```c
-void t8_forest_search_update_user_data (t8_forest_search_c_wrapper search, void *udata);
-```
-"""
-function t8_forest_search_update_user_data(search, udata)
-    @ccall libt8.t8_forest_search_update_user_data(search::t8_forest_search_c_wrapper, udata::Ptr{Cvoid})::Cvoid
-end
-
-"""
-    t8_forest_search_do_search(search)
-
-Perform the search
-
-# Arguments
-* `search`:\\[in,out\\] the search context to use
-### Prototype
-```c
-void t8_forest_search_do_search (t8_forest_search_c_wrapper search);
-```
-"""
-function t8_forest_search_do_search(search)
-    @ccall libt8.t8_forest_search_do_search(search::t8_forest_search_c_wrapper)::Cvoid
-end
-
-"""
-    t8_forest_search_destroy(search)
-
-Destroy the search context
-
-# Arguments
-* `search`:\\[in,out\\] the search context to destroy
-### Prototype
-```c
-void t8_forest_search_destroy (t8_forest_search_c_wrapper search);
-```
-"""
-function t8_forest_search_destroy(search)
-    @ccall libt8.t8_forest_search_destroy(search::t8_forest_search_c_wrapper)::Cvoid
-end
-
-mutable struct t8_forest_search_with_queries end
-
-"""A wrapper around the forest search with queries context"""
-const t8_forest_search_with_queries_c_wrapper = Ptr{t8_forest_search_with_queries}
-
-"""
-    t8_forest_init_search_with_queries(search_with_queries, element_callback, queries_callback, queries, num_queries, forest)
-
-### Prototype
-```c
-void t8_forest_init_search_with_queries (t8_forest_search_with_queries_c_wrapper search_with_queries, t8_search_element_callback_c_wrapper element_callback, t8_search_queries_callback_c_wrapper queries_callback, void **queries, const size_t num_queries, const t8_forest_t forest);
-```
-"""
-function t8_forest_init_search_with_queries(search_with_queries, element_callback, queries_callback, queries, num_queries, forest)
-    @ccall libt8.t8_forest_init_search_with_queries(search_with_queries::t8_forest_search_with_queries_c_wrapper, element_callback::t8_search_element_callback_c_wrapper, queries_callback::t8_search_queries_callback_c_wrapper, queries::Ptr{Ptr{Cvoid}}, num_queries::Csize_t, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_queries_update_forest(search_with_queries, forest)
-
-### Prototype
-```c
-void t8_forest_search_with_queries_update_forest (t8_forest_search_with_queries_c_wrapper search_with_queries, const t8_forest_t forest);
-```
-"""
-function t8_forest_search_with_queries_update_forest(search_with_queries, forest)
-    @ccall libt8.t8_forest_search_with_queries_update_forest(search_with_queries::t8_forest_search_with_queries_c_wrapper, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_queries_update_user_data(search_with_queries, udata)
-
-Update the user data pointer in the search with queries context
-
-# Arguments
-* `search_with_queries`:\\[in,out\\] the search with queries context to update
-* `udata`:\\[in\\] the new user data pointer to use
-### Prototype
-```c
-void t8_forest_search_with_queries_update_user_data (t8_forest_search_with_queries_c_wrapper search_with_queries, void *udata);
-```
-"""
-function t8_forest_search_with_queries_update_user_data(search_with_queries, udata)
-    @ccall libt8.t8_forest_search_with_queries_update_user_data(search_with_queries::t8_forest_search_with_queries_c_wrapper, udata::Ptr{Cvoid})::Cvoid
-end
-
-"""
-    t8_forest_search_with_queries_update_queries(search_with_queries, queries, num_queries)
-
-Update the queries in the search with queries context
-
-# Arguments
-* `search_with_queries`:\\[in,out\\] the search with queries context to update
-* `queries`:\\[in\\] a pointer to an array of queries
-* `num_queries`:\\[in\\] the number of queries in the array
-### Prototype
-```c
-void t8_forest_search_with_queries_update_queries (t8_forest_search_with_queries_c_wrapper search_with_queries, void **queries, const size_t num_queries);
-```
-"""
-function t8_forest_search_with_queries_update_queries(search_with_queries, queries, num_queries)
-    @ccall libt8.t8_forest_search_with_queries_update_queries(search_with_queries::t8_forest_search_with_queries_c_wrapper, queries::Ptr{Ptr{Cvoid}}, num_queries::Csize_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_queries_destroy(search)
-
-Destroy the search with queries context
-
-# Arguments
-* `search`:\\[in,out\\] the search with queries context to destroy
-### Prototype
-```c
-void t8_forest_search_with_queries_destroy (t8_forest_search_with_queries_c_wrapper search);
-```
-"""
-function t8_forest_search_with_queries_destroy(search)
-    @ccall libt8.t8_forest_search_with_queries_destroy(search::t8_forest_search_with_queries_c_wrapper)::Cvoid
-end
-
-"""
-    t8_forest_search_with_queries_do_search(search)
-
-Perform the search with queries
-
-# Arguments
-* `search`:\\[in,out\\] the search with queries context to use
-### Prototype
-```c
-void t8_forest_search_with_queries_do_search (t8_forest_search_with_queries_c_wrapper search);
-```
-"""
-function t8_forest_search_with_queries_do_search(search)
-    @ccall libt8.t8_forest_search_with_queries_do_search(search::t8_forest_search_with_queries_c_wrapper)::Cvoid
-end
-
-mutable struct t8_forest_search_with_batched_queries end
-
-"""A wrapper around the forest search with batched queries context"""
-const t8_forest_search_with_batched_queries_c_wrapper = Ptr{t8_forest_search_with_batched_queries}
-
-"""
-    t8_forest_init_search_with_batched_queries(search_with_queries, element_callback, queries_callback, queries, num_queries, forest)
-
-### Prototype
-```c
-void t8_forest_init_search_with_batched_queries (t8_forest_search_with_batched_queries_c_wrapper search_with_queries, t8_search_element_callback_c_wrapper element_callback, t8_search_batched_queries_callback_c_wrapper queries_callback, void **queries, const size_t num_queries, const t8_forest_t forest);
-```
-"""
-function t8_forest_init_search_with_batched_queries(search_with_queries, element_callback, queries_callback, queries, num_queries, forest)
-    @ccall libt8.t8_forest_init_search_with_batched_queries(search_with_queries::t8_forest_search_with_batched_queries_c_wrapper, element_callback::t8_search_element_callback_c_wrapper, queries_callback::t8_search_batched_queries_callback_c_wrapper, queries::Ptr{Ptr{Cvoid}}, num_queries::Csize_t, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_batched_queries_update_forest(search_with_queries, forest)
-
-### Prototype
-```c
-void t8_forest_search_with_batched_queries_update_forest ( t8_forest_search_with_batched_queries_c_wrapper search_with_queries, const t8_forest_t forest);
-```
-"""
-function t8_forest_search_with_batched_queries_update_forest(search_with_queries, forest)
-    @ccall libt8.t8_forest_search_with_batched_queries_update_forest(search_with_queries::t8_forest_search_with_batched_queries_c_wrapper, forest::t8_forest_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_batched_queries_update_user_data(search_with_queries, udata)
-
-Update the user data pointer in the search with batched queries context
-
-# Arguments
-* `search_with_queries`:\\[in,out\\] the search with batched queries context to update
-* `udata`:\\[in\\] the new user data pointer to use
-### Prototype
-```c
-void t8_forest_search_with_batched_queries_update_user_data ( t8_forest_search_with_batched_queries_c_wrapper search_with_queries, void *udata);
-```
-"""
-function t8_forest_search_with_batched_queries_update_user_data(search_with_queries, udata)
-    @ccall libt8.t8_forest_search_with_batched_queries_update_user_data(search_with_queries::t8_forest_search_with_batched_queries_c_wrapper, udata::Ptr{Cvoid})::Cvoid
-end
-
-"""
-    t8_forest_search_with_batched_queries_update_queries(search_with_queries, queries, num_queries)
-
-Update the queries in the search with batched queries context
-
-# Arguments
-* `search_with_queries`:\\[in,out\\] the search with batched queries context to update
-* `queries`:\\[in\\] a pointer to an array of queries
-* `num_queries`:\\[in\\] the number of queries in the array
-### Prototype
-```c
-void t8_forest_search_with_batched_queries_update_queries ( t8_forest_search_with_batched_queries_c_wrapper search_with_queries, void **queries, const size_t num_queries);
-```
-"""
-function t8_forest_search_with_batched_queries_update_queries(search_with_queries, queries, num_queries)
-    @ccall libt8.t8_forest_search_with_batched_queries_update_queries(search_with_queries::t8_forest_search_with_batched_queries_c_wrapper, queries::Ptr{Ptr{Cvoid}}, num_queries::Csize_t)::Cvoid
-end
-
-"""
-    t8_forest_search_with_batched_queries_destroy(search)
-
-Destroy the search with batched queries context
-
-# Arguments
-* `search`:\\[in,out\\] the search with batched queries context to destroy
-### Prototype
-```c
-void t8_forest_search_with_batched_queries_destroy (t8_forest_search_with_batched_queries_c_wrapper search);
-```
-"""
-function t8_forest_search_with_batched_queries_destroy(search)
-    @ccall libt8.t8_forest_search_with_batched_queries_destroy(search::t8_forest_search_with_batched_queries_c_wrapper)::Cvoid
-end
-
-"""
-    t8_forest_search_with_batched_queries_do_search(search)
-
-Perform the search with batched queries
-
-# Arguments
-* `search`:\\[in,out\\] the search with batched queries context to use
-### Prototype
-```c
-void t8_forest_search_with_batched_queries_do_search (t8_forest_search_with_batched_queries_c_wrapper search);
-```
-"""
-function t8_forest_search_with_batched_queries_do_search(search)
-    @ccall libt8.t8_forest_search_with_batched_queries_do_search(search::t8_forest_search_with_batched_queries_c_wrapper)::Cvoid
-end
-
 # typedef void ( * t8_geom_analytic_fn ) ( t8_cmesh_t cmesh , t8_gloidx_t gtreeid , const double * ref_coords , const size_t num_coords , double * out_coords , const void * tree_data , const void * user_data )
 """
 Definition of an analytic geometry function. This function maps reference coordinates to physical coordinates.
 
 ```c++
- [0,1]^\\mathrm{dim} 
+ [0,1]^\\mathrm{dim}
 ```
 
 .
@@ -16783,7 +17716,7 @@ Definition of an analytic geometry function. This function maps reference coordi
 * `cmesh`:\\[in\\] The cmesh.
 * `gtreeid`:\\[in\\] The global tree (of the cmesh) in which the reference point is.
 * `ref_coords`:\\[in\\] Array of dimension x *num_coords* many entries, specifying a point in
-* `num_coords`:\\[in\\] The number of coordinates in *ref_coords*.
+* `num_coords`:\\[in\\]
 * `out_coords`:\\[out\\] The mapped coordinates in physical space of *ref_coords*. The length is *num_coords* * 3.
 * `tree_data`:\\[in\\] The data of the current tree as loaded by a t8_geom_load_tree_data_fn.
 * `user_data`:\\[in\\] The user data pointer stored in the geometry.
@@ -16795,19 +17728,19 @@ const t8_geom_analytic_fn = Ptr{Cvoid}
 Definition for the jacobian of an analytic geometry function.
 
 ```c++
- [0,1]^\\mathrm{dim} 
+ [0,1]^\\mathrm{dim}
 ```
 
 .
 
 ```c++
- \\mathrm{dim} 
+ \\mathrm{dim}
 ```
 
 to map.
 
 ```c++
- \\mathrm{dim} \\cdot 3 
+ \\mathrm{dim} \\cdot 3
 ```
 
 x *num_coords*. Indices
@@ -16819,31 +17752,31 @@ x *num_coords*. Indices
 ,
 
 ```c++
- 3 \\cdot i+1 
+ 3 \\cdot i+1
 ```
 
 ,
 
 ```c++
- 3 \\cdot i+2 
+ 3 \\cdot i+2
 ```
 
 correspond to the
 
 ```c++
- i 
+ i
 ```
 
 -th column of the jacobian (Entry
 
 ```c++
- 3 \\cdot i + j 
+ 3 \\cdot i + j
 ```
 
 is
 
 ```c++
- \\frac{\\partial f_j}{\\partial x_i} 
+ \\frac{\\partial f_j}{\\partial x_i}
 ```
 
 ).
@@ -16881,59 +17814,37 @@ const t8_geom_tree_compatible_fn = Ptr{Cvoid}
 """
     t8_geometry_analytic_destroy(geom)
 
-Destroy a geometry analytic object.
-
-# Arguments
-* `geom`:\\[in,out\\] A pointer to a geometry object. Set to NULL on output.
 ### Prototype
 ```c
 void t8_geometry_analytic_destroy (t8_geometry_c **geom);
 ```
 """
 function t8_geometry_analytic_destroy(geom)
-    @ccall libt8.t8_geometry_analytic_destroy(geom::Ptr{Ptr{t8_geometry_c}})::Cvoid
+    @ccall libt8.t8_geometry_analytic_destroy(geom::Ptr{Ptr{Cint}})::Cvoid
 end
 
 """
     t8_geometry_analytic_new(name, analytical, jacobian, load_tree_data, tree_negative_volume, tree_compatible, user_data)
 
-Create a new analytic geometry. The geometry is viable with all tree types and uses a user-provided analytic and jacobian function. The actual mappings are done by these functions.
-
-# Arguments
-* `name`:\\[in\\] The name to give this geometry.
-* `analytical`:\\[in\\] The analytical function to use for this geometry.
-* `jacobian`:\\[in\\] The jacobian of *analytical*.
-* `load_tree_data`:\\[in\\] The function that is used to load a tree's data.
-* `tree_negative_volume`:\\[in\\] The function that is used to compute if a trees volume is negative.
-* `tree_compatible`:\\[in\\] The function that is used to check if a tree is compatible with the geometry.
-* `user_data`:\\[in\\] Additional user data which the geometry can use.
-# Returns
-A pointer to an allocated geometry struct.
 ### Prototype
 ```c
 t8_geometry_c * t8_geometry_analytic_new (const char *name, t8_geom_analytic_fn analytical, t8_geom_analytic_jacobian_fn jacobian, t8_geom_load_tree_data_fn load_tree_data, t8_geom_tree_negative_volume_fn tree_negative_volume, t8_geom_tree_compatible_fn tree_compatible, const void *user_data);
 ```
 """
 function t8_geometry_analytic_new(name, analytical, jacobian, load_tree_data, tree_negative_volume, tree_compatible, user_data)
-    @ccall libt8.t8_geometry_analytic_new(name::Cstring, analytical::t8_geom_analytic_fn, jacobian::t8_geom_analytic_jacobian_fn, load_tree_data::t8_geom_load_tree_data_fn, tree_negative_volume::t8_geom_tree_negative_volume_fn, tree_compatible::t8_geom_tree_compatible_fn, user_data::Ptr{Cvoid})::Ptr{t8_geometry_c}
+    @ccall libt8.t8_geometry_analytic_new(name::Cstring, analytical::t8_geom_analytic_fn, jacobian::t8_geom_analytic_jacobian_fn, load_tree_data::t8_geom_load_tree_data_fn, tree_negative_volume::t8_geom_tree_negative_volume_fn, tree_compatible::t8_geom_tree_compatible_fn, user_data::Ptr{Cvoid})::Ptr{Cint}
 end
 
 """
     t8_geom_load_tree_data_vertices(cmesh, gtreeid, user_data)
 
-Load vertex data from given tree.
-
-# Arguments
-* `cmesh`:\\[in\\] The cmesh.
-* `gtreeid`:\\[in\\] The global tree id (in the cmesh).
-* `user_data`:\\[out\\] The load tree vertices.
 ### Prototype
 ```c
 void t8_geom_load_tree_data_vertices (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const void **user_data);
 ```
 """
 function t8_geom_load_tree_data_vertices(cmesh, gtreeid, user_data)
-    @ccall libt8.t8_geom_load_tree_data_vertices(cmesh::t8_cmesh_t, gtreeid::t8_gloidx_t, user_data::Ptr{Ptr{Cvoid}})::Cvoid
+    @ccall libt8.t8_geom_load_tree_data_vertices(cmesh::t8_cmesh_t, gtreeid::Cint, user_data::Ptr{Ptr{Cvoid}})::Cvoid
 end
 
 """
@@ -17187,34 +18098,42 @@ function t8_geometry_zero_destroy(geom)
 end
 
 """
-    t8_scheme_new_default()
+    t8_scheme_new_default_cxx()
+
+Return the default element implementation of t8code.
 
 ### Prototype
 ```c
-const t8_scheme_c * t8_scheme_new_default (void);
+t8_scheme_cxx_t * t8_scheme_new_default_cxx (void);
 ```
 """
-function t8_scheme_new_default()
-    @ccall libt8.t8_scheme_new_default()::Ptr{Cint}
+function t8_scheme_new_default_cxx()
+    @ccall libt8.t8_scheme_new_default_cxx()::Ptr{t8_scheme_cxx_t}
 end
 
 """
-    t8_eclass_scheme_is_default(scheme, eclass)
+    t8_eclass_scheme_is_default(ts)
 
+Check whether a given eclass\\_scheme is one of the default schemes.
+
+# Arguments
+* `ts`:\\[in\\] A (pointer to a) scheme
+# Returns
+True (non-zero) if *ts* is one of the default schemes, false (zero) otherwise.
 ### Prototype
 ```c
-int t8_eclass_scheme_is_default (const t8_scheme_c *scheme, const t8_eclass_t eclass);
+int t8_eclass_scheme_is_default (t8_eclass_scheme_c *ts);
 ```
 """
-function t8_eclass_scheme_is_default(scheme, eclass)
-    @ccall libt8.t8_eclass_scheme_is_default(scheme::Ptr{Cint}, eclass::t8_eclass_t)::Cint
+function t8_eclass_scheme_is_default(ts)
+    @ccall libt8.t8_eclass_scheme_is_default(ts::Ptr{t8_eclass_scheme_c})::Cint
 end
 
-const SC_CC = "/opt/bin/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpich/x86_64-linux-gnu-gcc"
+const SC_CC = "/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/bin/mpicc"
 
 const SC_CFLAGS = " "
 
-const SC_CPP = "/opt/bin/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpich/x86_64-linux-gnu-gcc -E"
+const SC_CPP = "/opt/x86_64-linux-gnu/x86_64-linux-gnu/sys-root/usr/local/bin/mpicc -E"
 
 const SC_CPPFLAGS = ""
 
@@ -17230,14 +18149,6 @@ const SC_ENABLE_MPICOMMSHARED = 1
 
 const SC_ENABLE_MPIIO = 1
 
-const SC_HAVE_AINT_DIFF = 1
-
-const SC_HAVE_MPI_UNSIGNED_LONG_LONG = 1
-
-const SC_HAVE_MPI_SIGNED_CHAR = 1
-
-const SC_HAVE_MPI_INT8_T = 1
-
 const SC_ENABLE_MPITHREAD = 1
 
 const SC_ENABLE_MPIWINSHARED = 1
@@ -17248,15 +18159,11 @@ const SC_ENABLE_USE_REALLOC = 1
 
 const SC_ENABLE_V4L2 = 1
 
-const SC_HAVE_ALIGNED_ALLOC = 1
-
 const SC_HAVE_BACKTRACE = 1
 
 const SC_HAVE_BACKTRACE_SYMBOLS = 1
 
 const SC_HAVE_FSYNC = 1
-
-const SC_HAVE_POSIX_MEMALIGN = 1
 
 const SC_HAVE_FABS = 1
 
@@ -17282,13 +18189,13 @@ const SC_PACKAGE_BUGREPORT = "p4est@ins.uni-bonn.de"
 
 const SC_PACKAGE_NAME = "libsc"
 
-const SC_PACKAGE_STRING = "libsc 2.8.6.999"
+const SC_PACKAGE_STRING = "libsc 0.0.0"
 
 const SC_PACKAGE_TARNAME = "libsc"
 
 const SC_PACKAGE_URL = ""
 
-const SC_PACKAGE_VERSION = "2.8.6.999"
+const SC_PACKAGE_VERSION = "0.0.0"
 
 const SC_SIZEOF_INT = 4
 
@@ -17296,29 +18203,53 @@ const SC_SIZEOF_UNSIGNED_INT = 4
 
 const SC_SIZEOF_LONG = 8
 
-const SC_SIZEOF_UNSIGNED_LONG = 8
-
 const SC_SIZEOF_LONG_LONG = 8
 
-const SC_VERSION = "2.8.6.999"
+const SC_SIZEOF_UNSIGNED_LONG = 8
 
-const SC_VERSION_MAJOR = 2
+const SC_SIZEOF_UNSIGNED_LONG_LONG = 8
 
-const SC_VERSION_MINOR = 8
+const SC_VERSION = "0.0.0"
 
-const SC_VERSION_POINT = 6
+const SC_VERSION_MAJOR = 0
 
-# Skipping MacroDefinition: _sc_const const
+const SC_VERSION_MINOR = 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 const sc_MPI_COMM_WORLD = MPI.COMM_WORLD
 
 const sc_MPI_COMM_SELF = MPI.COMM_SELF
 
-const sc_MPI_BYTE = MPI.BYTE
-
 const sc_MPI_CHAR = MPI.CHAR
 
+const sc_MPI_SIGNED_CHAR = MPI.SIGNED_CHAR
+
 const sc_MPI_UNSIGNED_CHAR = MPI.UNSIGNED_CHAR
+
+const sc_MPI_BYTE = MPI.BYTE
 
 const sc_MPI_SHORT = MPI.SHORT
 
@@ -17326,23 +18257,22 @@ const sc_MPI_UNSIGNED_SHORT = MPI.UNSIGNED_SHORT
 
 const sc_MPI_INT = MPI.INT
 
+const sc_MPI_INT8_T = MPI.INT8_T
+
 const sc_MPI_UNSIGNED = MPI.UNSIGNED
 
 const sc_MPI_LONG = MPI.LONG
 
 const sc_MPI_UNSIGNED_LONG = MPI.UNSIGNED_LONG
 
-const sc_MPI_UNSIGNED_LONG_LONG = MPI.UNSIGNED_LONG_LONG
-
-const sc_MPI_SIGNED_CHAR = MPI.SIGNED_CHAR
-
-const sc_MPI_INT8_T = MPI.INT8_T
-
 const sc_MPI_LONG_LONG_INT = MPI.LONG_LONG_INT
+
+const sc_MPI_UNSIGNED_LONG_LONG = MPI.UNSIGNED_LONG_LONG
 
 const sc_MPI_FLOAT = MPI.FLOAT
 
 const sc_MPI_DOUBLE = MPI.DOUBLE
+
 
 const sc_MPI_Comm = MPI.Comm
 
@@ -17352,9 +18282,36 @@ const sc_MPI_Datatype = MPI.Datatype
 
 const sc_MPI_Info = MPI.Info
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 const sc_MPI_File = MPI.File
 
 const sc_MPI_FILE_NULL = MPI.FILE_NULL
+
+
+
+
+
+
+
+
+
+
 
 const SC_EPS = 2.220446049250313e-16
 
@@ -17388,13 +18345,13 @@ const SC_LP_SILENT = 9
 
 const SC_LP_THRESHOLD = SC_LP_INFO
 
+
+
 const T8_MPI_LOCIDX = sc_MPI_INT
 
 const T8_LOCIDX_MAX = INT32_MAX
 
 const T8_MPI_GLOIDX = sc_MPI_LONG_LONG_INT
-
-const T8_GLOIDX_MAX = INT64_MAX
 
 const T8_MPI_LINEARIDX = sc_MPI_UNSIGNED_LONG_LONG
 
@@ -17403,6 +18360,39 @@ const T8_MPI_LINEARIDX = sc_MPI_UNSIGNED_LONG_LONG
 const T8_PRECISION_EPS = SC_EPS
 
 const T8_PRECISION_SQRT_EPS = sqrt(T8_PRECISION_EPS)
+
+const T8_CMESH_N_SUPPORTED_MSH_FILE_VERSIONS = 2
+
+# Skipping MacroDefinition: T8_MPI_ECLASS_TYPE ( T8_ASSERT ( sizeof ( int ) == sizeof ( t8_eclass_t ) ) , sc_MPI_INT )
+
+const T8_ECLASS_MAX_FACES = 6
+
+const T8_ECLASS_MAX_EDGES = 12
+
+const T8_ECLASS_MAX_EDGES_2D = 4
+
+const T8_ECLASS_MAX_CORNERS_2D = 4
+
+const T8_ECLASS_MAX_CORNERS = 8
+
+const T8_ECLASS_MAX_DIM = 3
+
+# Skipping MacroDefinition: T8_MPI_ELEMENT_SHAPE_TYPE ( T8_ASSERT ( sizeof ( int ) == sizeof ( t8_element_shape_t ) ) , sc_MPI_INT )
+
+const T8_ELEMENT_SHAPE_MAX_FACES = 6
+
+const T8_ELEMENT_SHAPE_MAX_CORNERS = 8
+
+
+const T8_VTK_LOCIDX = "Int32"
+
+const T8_VTK_GLOIDX = "Int32"
+
+const T8_VTK_FLOAT_NAME = "Float32"
+
+const T8_VTK_FLOAT_TYPE = Float32
+
+const T8_VTK_FORMAT_STRING = "ascii"
 
 const sc_mpi_read = sc_io_read
 
@@ -17426,8 +18416,6 @@ const P4EST_ENABLE_MEMALIGN = 1
 
 const P4EST_ENABLE_MPI = 1
 
-const P4EST_ENABLE_FILE_CHECKS = 1
-
 const P4EST_ENABLE_MPICOMMSHARED = 1
 
 const P4EST_ENABLE_MPIIO = 1
@@ -17442,8 +18430,6 @@ const P4EST_ENABLE_VTK_COMPRESSION = 1
 
 const P4EST_HAVE_FSYNC = 1
 
-const P4EST_HAVE_POSIX_MEMALIGN = 1
-
 const P4EST_HAVE_ZLIB = 1
 
 const P4EST_LDFLAGS = "-Wl,-rpath -Wl,/workspace/destdir/lib -Wl,--enable-new-dtags -L/workspace/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpich/destdir/lib"
@@ -17456,21 +18442,20 @@ const P4EST_PACKAGE_BUGREPORT = "p4est@ins.uni-bonn.de"
 
 const P4EST_PACKAGE_NAME = "p4est"
 
-const P4EST_PACKAGE_STRING = "p4est 2.8.6.999"
+const P4EST_PACKAGE_STRING = "p4est 0.0.0"
 
 const P4EST_PACKAGE_TARNAME = "p4est"
 
 const P4EST_PACKAGE_URL = ""
 
-const P4EST_PACKAGE_VERSION = "2.8.6.999"
+const P4EST_PACKAGE_VERSION = "0.0.0"
 
-const P4EST_VERSION = "2.8.6.999"
+const P4EST_VERSION = "0.0.0"
 
-const P4EST_VERSION_MAJOR = 2
+const P4EST_VERSION_MAJOR = 0
 
-const P4EST_VERSION_MINOR = 8
+const P4EST_VERSION_MINOR = 0
 
-const P4EST_VERSION_POINT = 6
 
 const p4est_qcoord_compare = sc_int32_compare
 
@@ -17479,6 +18464,7 @@ const P4EST_QCOORD_BITS = 32
 const P4EST_MPI_QCOORD = sc_MPI_INT
 
 const P4EST_VTK_QCOORD = "Int32"
+
 
 const P4EST_QCOORD_MIN = INT32_MIN
 
@@ -17493,6 +18479,7 @@ const P4EST_TOPIDX_BITS = 32
 const P4EST_MPI_TOPIDX = sc_MPI_INT
 
 const P4EST_VTK_TOPIDX = "Int32"
+
 
 const P4EST_TOPIDX_MIN = INT32_MIN
 
@@ -17510,6 +18497,7 @@ const P4EST_MPI_LOCIDX = sc_MPI_INT
 
 const P4EST_VTK_LOCIDX = "Int32"
 
+
 const P4EST_LOCIDX_MIN = INT32_MIN
 
 const P4EST_LOCIDX_MAX = INT32_MAX
@@ -17524,11 +18512,16 @@ const P4EST_MPI_GLOIDX = sc_MPI_LONG_LONG_INT
 
 const P4EST_VTK_GLOIDX = "Int64"
 
+
 const P4EST_GLOIDX_MIN = INT64_MIN
 
 const P4EST_GLOIDX_MAX = INT64_MAX
 
 const P4EST_GLOIDX_1 = p4est_gloidx_t(1)
+
+
+
+
 
 const P4EST_DIM = 2
 
@@ -17564,59 +18557,27 @@ const P8EST_STRING = "p8est"
 
 const P8EST_ONDISK_FORMAT = 0x03000009
 
+const T8_CMESH_FORMAT = 0x0002
+
+const T8_CMESH_VERTICES_ATTRIBUTE_KEY = 0
+
+const T8_CMESH_GEOMETRY_ATTRIBUTE_KEY = 1
+
+const T8_CMESH_CAD_EDGE_ATTRIBUTE_KEY = 2
+
+const T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY = 3
+
+const T8_CMESH_CAD_FACE_ATTRIBUTE_KEY = T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY + T8_ECLASS_MAX_EDGES
+
+const T8_CMESH_CAD_FACE_PARAMETERS_ATTRIBUTE_KEY = T8_CMESH_CAD_FACE_ATTRIBUTE_KEY + 1
+
+const T8_CMESH_LAGRANGE_POLY_DEGREE_KEY = T8_CMESH_CAD_FACE_PARAMETERS_ATTRIBUTE_KEY + T8_ECLASS_MAX_FACES
+
+const T8_CMESH_NEXT_POSSIBLE_KEY = T8_CMESH_LAGRANGE_POLY_DEGREE_KEY + 1
+
+const T8_CPROFILE_NUM_STATS = 11
+
 const T8_SHMEM_BEST_TYPE = SC_SHMEM_WINDOW
-
-# Skipping MacroDefinition: T8_MPI_ECLASS_TYPE ( T8_ASSERT ( sizeof ( int ) == sizeof ( t8_eclass_t ) ) , sc_MPI_INT )
-
-const T8_ECLASS_MAX_FACES = 6
-
-const T8_ECLASS_MAX_EDGES = 12
-
-const T8_ECLASS_MAX_EDGES_2D = 4
-
-const T8_ECLASS_MAX_CORNERS_2D = 4
-
-const T8_ECLASS_MAX_CORNERS = 8
-
-const T8_ECLASS_MAX_DIM = 3
-
-const T8_ECLASS_MAX_CHILDREN = 10
-
-# Skipping MacroDefinition: T8_FACE_VERTEX_TO_TREE_VERTEX_VALUES { { { - 1 } } , /* vertex */ { { 0 } , { 1 } } , /* line */ { { 0 , 2 } , { 1 , 3 } , { 0 , 1 } , { 2 , 3 } } , /* quad */ { { 1 , 2 } , { 0 , 2 } , { 0 , 1 } } , /* triangle */ { { 0 , 2 , 4 , 6 } , { 1 , 3 , 5 , 7 } , { 0 , 1 , 4 , 5 } , { 2 , 3 , 6 , 7 } , { 0 , 1 , 2 , 3 } , { 4 , 5 , 6 , 7 } } , /* hex */ { { 1 , 2 , 3 } , { 0 , 2 , 3 } , { 0 , 1 , 3 } , { 0 , 1 , 2 } } , /* tet */ { { 1 , 2 , 4 , 5 } , { 0 , 2 , 3 , 5 } , { 0 , 1 , 3 , 4 } , { 0 , 1 , 2 } , { 3 , 4 , 5 } } , /* prism */ { { 0 , 2 , 4 } , { 1 , 3 , 4 } , { 0 , 1 , 4 } , { 2 , 3 , 4 } , { 0 , 1 , 2 , 3 } } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_FACE_EDGE_TO_TREE_EDGE_VALUES { { { - 1 } } , /* vertex */ { { 0 } } , /* line */ { { 0 } , { 1 } , { 2 } , { 3 } } , /* quad */ { { 0 } , { 1 } , { 2 } } , /* triangle */ { { 8 , 10 , 4 , 6 } , { 9 , 11 , 5 , 7 } , { 8 , 9 , 0 , 2 } , { 10 , 11 , 1 , 3 } , { 4 , 5 , 0 , 1 } , { 6 , 7 , 2 , 3 } } , /* hex */ { { 3 , 4 , 5 } , { 1 , 2 , 5 } , { 0 , 2 , 4 } , { 0 , 1 , 3 } } , /* tet */ { { 0 , 7 , 3 , 6 } , { 1 , 8 , 4 , 7 } , { 2 , 6 , 5 , 8 } , { 0 , 1 , 2 } , { 3 , 4 , 5 } } , /* prism */ { { - 1 } } , /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_FACE_TO_EDGE_NEIGHBOR_VALUES { { { - 1 } } , /* vertex */ { { - 1 } } , /* line */ { { 2 , 3 } , { 2 , 3 } , { 0 , 1 } , { 0 , 1 } } , /* quad */ { { 2 , 1 } , { 2 , 0 } , { 1 , 0 } } , /* triangle */ { { 0 , 1 , 2 , 3 } , { 0 , 1 , 2 , 3 } , { 4 , 5 , 6 , 7 } , { 4 , 5 , 6 , 7 } , { 8 , 9 , 10 , 11 } , { 8 , 9 , 10 , 11 } } , /* hex */ { { 0 , 1 , 2 } , { 0 , 3 , 4 } , { 1 , 3 , 5 } , { 2 , 4 , 5 } } , /* tet */ { { 1 , 2 , 4 , 5 } , { 0 , 2 , 3 , 5 } , { 0 , 1 , 3 , 4 } , { 6 , 7 , 8 } , { 6 , 7 , 8 } } , /* prism */ { { - 1 } } , /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_EDGE_VERTEX_TO_TREE_VERTEX_VALUES { { { - 1 } } , /* vertex */ { { 0 } , { 1 } } , /* line */ { { 0 , 2 } , { 1 , 3 } , { 0 , 1 } , { 2 , 3 } } , /* quad */ { { 1 , 2 } , { 0 , 2 } , { 0 , 1 } } , /* triangle */ { { 0 , 1 } , { 2 , 3 } , { 4 , 5 } , { 6 , 7 } , { 0 , 2 } , { 1 , 3 } , { 4 , 6 } , { 5 , 7 } , { 0 , 4 } , { 1 , 5 } , { 2 , 6 } , { 3 , 7 } } , /* hex */ { { 0 , 1 } , { 0 , 2 } , { 0 , 3 } , { 1 , 2 } , { 1 , 3 } , { 2 , 3 } } , /* tet */ { { 1 , 2 } , { 0 , 2 } , { 0 , 1 } , { 4 , 5 } , { 3 , 5 } , { 3 , 4 } , { 1 , 4 } , { 2 , 5 } , { 0 , 3 } } , /* prism */ { { - 1 } } , /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_EDGE_TO_FACE_VALUES { { { - 1 } } , /* vertex */ { { 0 } } , /* line */ { { 0 } , { 1 } , { 2 } , { 3 } } , /* quad */ { { 0 } , { 1 } , { 2 } } , /* triangle */ { { 2 , 4 } , { 3 , 4 } , { 2 , 5 } , { 3 , 5 } , { 0 , 4 } , { 1 , 4 } , { 0 , 5 } , { 1 , 5 } , { 0 , 2 } , { 1 , 2 } , { 0 , 3 } , { 1 , 3 } } , /* hex */ { { 2 , 3 } , { 1 , 3 } , { 1 , 2 } , { 0 , 3 } , { 0 , 2 } , { 0 , 1 } } , /* tet */ { { 0 , 3 } , { 1 , 3 } , { 2 , 3 } , { 0 , 4 } , { 1 , 4 } , { 2 , 4 } , { 0 , 2 } , { 0 , 1 } , { 1 , 2 } } , /* prism */ { { - 1 } } , /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_ECLASS_FACE_ORIENTATION_VALUES { { 0 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* vertex */ { 0 , 0 , - 1 , - 1 , - 1 , - 1 } , /* line */ { 0 , 0 , 0 , 0 , - 1 , - 1 } , /* quad */ { 0 , 0 , 0 , - 1 , - 1 , - 1 } , /* triangle */ { 0 , 1 , 1 , 0 , 0 , 1 } , /* hex */ { 0 , 1 , 0 , 1 , - 1 , - 1 } , /* tet */ { 1 , 0 , 1 , 0 , 1 , - 1 } , /* prism */ { 0 , 1 , 1 , 0 , 0 , - 1 } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_ECLASS_VTK_TO_T8_CORNER_NUMBER_VALUES { { 0 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* vertex */ { 0 , 1 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* line */ { 0 , 1 , 3 , 2 , - 1 , - 1 , - 1 , - 1 } , /* quad */ { 0 , 1 , 2 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* triangle */ { 0 , 1 , 3 , 2 , 4 , 5 , 7 , 6 } , /* hex */ { 0 , 2 , 1 , 3 , - 1 , - 1 , - 1 , - 1 } , /* tet */ { 0 , 2 , 1 , 3 , 5 , 4 , - 1 , - 1 } , /* prism */ { 0 , 1 , 3 , 2 , 4 , - 1 , - 1 , - 1 } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_ECLASS_T8_TO_VTK_CORNER_NUMBER_VALUES { { 0 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* vertex */ { 0 , 1 , - 1 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* line */ { 0 , 1 , 3 , 2 , - 1 , - 1 , - 1 , - 1 } , /* quad */ { 0 , 1 , 2 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* triangle */ { 0 , 1 , 3 , 2 , 4 , 5 , 7 , 6 } , /* hex */ { 0 , 2 , 1 , 3 , - 1 , - 1 , - 1 , - 1 } , /* tet */ { 0 , 2 , 1 , 3 , 5 , 4 , - 1 , - 1 } , /* prism */ { 0 , 1 , 3 , 2 , 4 , - 1 , - 1 , - 1 } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_ECLASS_FACE_TYPES_VALUES { { - 1 , - 1 , - 1 , - 1 , - 1 , - 1 } , /* vertex */ { 0 , 0 , - 1 , - 1 , - 1 , - 1 } , /* line */ { 1 , 1 , 1 , 1 , - 1 , - 1 } , /* quad */ { 1 , 1 , 1 , - 1 , - 1 , - 1 } , /* triangle */ { 2 , 2 , 2 , 2 , 2 , 2 } , /* hex */ { 3 , 3 , 3 , 3 , - 1 , - 1 } , /* tet */ { 2 , 2 , 2 , 3 , 3 , - 1 } , /* prism */ { 3 , 3 , 3 , 3 , 2 , - 1 } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_ECLASS_BOUNDARY_COUNT_VALUES { { 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 } , /* vertex */ { 2 , 0 , 0 , 0 , 0 , 0 , 0 , 0 } , /* line */ { 4 , 4 , 0 , 0 , 0 , 0 , 0 , 0 } , /* quad */ { 3 , 3 , 0 , 0 , 0 , 0 , 0 , 0 } , /* triangle */ { 8 , 12 , 6 , 0 , 0 , 0 , 0 , 0 } , /* hex */ { 4 , 6 , 0 , 4 , 0 , 0 , 0 , 0 } , /* tet */ { 6 , 9 , 3 , 2 , 0 , 0 , 0 , 0 } , /* prism */ { 5 , 8 , 1 , 4 , 0 , 0 , 0 , 0 } /* pyramid */ \
-#}
-
-# Skipping MacroDefinition: T8_MPI_ELEMENT_SHAPE_TYPE ( T8_ASSERT ( sizeof ( int ) == sizeof ( t8_element_shape_t ) ) , sc_MPI_INT )
-
-const T8_ELEMENT_SHAPE_MAX_FACES = 6
-
-const T8_ELEMENT_SHAPE_MAX_CORNERS = 8
 
 const T8_FOREST_FROM_FIRST = 0
 
@@ -17636,23 +18597,9 @@ const T8_FOREST_BALANCE_REPART = 1
 
 const T8_FOREST_BALANCE_NO_REPART = 2
 
-const T8_PROFILE_NUM_STATS = 17
+const T8_PROFILE_NUM_STATS = 14
 
-# Skipping MacroDefinition: T8_THROW_ERROR_WITH @ "Invalid usage of T8_WITH_*. Use T8_ENABLE_* instead."
 
-const T8_VTK_LOCIDX = "Int32"
-
-const T8_VTK_GLOIDX = "Int32"
-
-const T8_VTK_FLOAT_NAME = "Float32"
-
-const T8_VTK_FLOAT_TYPE = Float32
-
-const T8_VTK_FORMAT_STRING = "ascii"
-
-const T8_CMESH_N_SUPPORTED_MSH_FILE_VERSIONS = 1
-
-const T8_CMESH_FORMAT = 0x0002
 
 # exports
 const PREFIXES = ["t8_", "T8_"]

--- a/src/T8code.jl
+++ b/src/T8code.jl
@@ -262,15 +262,14 @@ function t8_free(ptr)
     Libt8.sc_free(t8_get_package_id(), ptr)
 end
 
-# typedef int (*t8_forest_adapt_t) (t8_forest_t forest,
-#                                   t8_forest_t forest_from,
-#                                   t8_locidx_t which_tree,
-#                                   const t8_eclass_t tree_class,
-#                                   t8_locidx_t lelement_id,
-#                                   const t8_scheme_c *scheme,
-#                                   const int is_family,
-#                                   const int num_elements,
-#                                   t8_element_t *elements[]);
+# typedef int         (*t8_forest_adapt_t) (t8_forest_t forest,
+#                                           t8_forest_t forest_from,
+#                                           t8_locidx_t which_tree,
+#                                           t8_locidx_t lelement_id,
+#                                           t8_eclass_scheme_c *ts,
+#                                           const int is_family,
+#                                           const int num_elements,
+#                                           t8_element_t *elements[]);
 """
     @t8_adapt_callback(callback)
 
@@ -279,8 +278,8 @@ signature required for callback functions in [`t8_forest_adapt`](@ref).
 """
 macro t8_adapt_callback(callback)
     :(@cfunction($callback, Cint,
-                 (Ptr{t8_forest}, Ptr{t8_forest}, t8_locidx_t, t8_eclass_t, t8_locidx_t,
-                  Ptr{t8_scheme}, Cint, Cint, Ptr{Ptr{t8_element}})))
+                 (Ptr{t8_forest}, Ptr{t8_forest}, t8_locidx_t, t8_locidx_t,
+                  Ptr{t8_eclass_scheme}, Cint, Cint, Ptr{Ptr{t8_element}})))
 end
 
 # typedef void        (*t8_forest_replace_t) (t8_forest_t forest_old,

--- a/test/cmesh/test_readmshfile.jl
+++ b/test/cmesh/test_readmshfile.jl
@@ -69,6 +69,20 @@ function t8_supported_msh_file(cmesh)
 end
 
 @testset "readmshfile" begin
+    @testset "test_msh_file_vers2_ascii" begin
+        fileprefix = joinpath(@__DIR__, "testfiles", "test_msh_file_vers2_ascii")
+        filename = fileprefix * ".msh"
+
+        @assert isfile(filename) "File not found: "*filename
+
+        cmesh = t8_cmesh_from_msh_file(fileprefix, 1, comm, 2, 0, 0)
+
+        @assert cmesh!=C_NULL "Could not read cmesh from ascii version 2, but should be able to: "*filename
+
+        t8_supported_msh_file(cmesh)
+        t8_cmesh_destroy(Ref(cmesh))
+    end
+
     @testset "test_msh_file_vers4_ascii" begin
         fileprefix = joinpath(@__DIR__, "testfiles", "test_msh_file_vers4_ascii")
         filename = fileprefix * ".msh"
@@ -80,6 +94,21 @@ end
         @assert cmesh!=C_NULL "Could not read cmesh from ascii version 4, but should be able to: "*filename
 
         t8_cmesh_destroy(Ref(cmesh))
+    end
+
+    @testset "test_msh_file_vers2_bin" begin
+        fileprefix = joinpath(@__DIR__, "testfiles", "test_msh_file_vers2_bin")
+        filename = fileprefix * ".msh"
+
+        @assert isfile(filename) "File not found: "*filename
+
+        cmesh = t8_cmesh_from_msh_file(fileprefix, 1, comm, 2, 0, 0)
+
+        @assert cmesh==C_NULL "Expected fail of reading binary msh file v.2, but did not fail."
+
+        if cmesh != C_NULL
+            t8_cmesh_destroy(Ref(cmesh))
+        end
     end
 
     @testset "test_msh_file_vers4_bin" begin

--- a/test/forest/test_element_volume.jl
+++ b/test/forest/test_element_volume.jl
@@ -13,10 +13,9 @@
 # elements and compute it element-specific. 
 # \param[in] pyra A pyramid
 # \return The volume of the pyramid 
-function pyramid_control_volume(scheme::Ptr{t8_scheme},
-                                tree_class::t8_eclass,
+function pyramid_control_volume(eclass_scheme::Ptr{t8_eclass_scheme},
                                 pyra::Ptr{t8_element})::Cdouble
-    level = t8_element_get_level(scheme, tree_class, pyra)
+    level = t8_element_level(eclass_scheme, pyra)
     # Both pyramids and tets have 1/8th of the parents volume, if the shape does not switch.
     control_volume = 1.0 / 3.0 / (1 << (level * 3))
 
@@ -36,12 +35,12 @@ end
 
     for eclass in T8_ECLASS_ZERO:t8_eclass(T8_ECLASS_COUNT - 1)
         for level in 0:4
-            scheme = t8_scheme_new_default()
+            scheme = t8_scheme_new_default_cxx()
             cmesh = t8_cmesh_new_hypercube(t8_eclass(eclass), comm, 0, 0, 0)
             forest = t8_forest_new_uniform(cmesh, scheme, level, 0, comm)
 
             # Compute the global number of elements.
-            global_num_elements = t8_forest_get_global_num_leaf_elements(forest)
+            global_num_elements = t8_forest_get_global_num_elements(forest)
 
             # Vertices have a volume of 0.
             control_volume = (eclass == T8_ECLASS_VERTEX) ? 0.0 :
@@ -49,18 +48,17 @@ end
 
             local_num_trees = t8_forest_get_num_local_trees(forest)
 
-            # Get the scheme used by this forest
-            scheme = t8_forest_get_scheme(forest)
-
             # Iterate over all elements.
             for itree in 0:(local_num_trees - 1)
                 tree_class = t8_forest_get_tree_class(forest, itree)
-                tree_elements = t8_forest_get_tree_num_leaf_elements(forest, itree)
+                eclass_scheme = t8_forest_get_eclass_scheme(forest, tree_class)
+
+                tree_elements = t8_forest_get_tree_num_elements(forest, itree)
                 for ielement in 0:(tree_elements - 1)
-                    element = t8_forest_get_leaf_element_in_tree(forest, itree, ielement)
+                    element = t8_forest_get_element_in_tree(forest, itree, ielement)
                     volume = t8_forest_element_volume(forest, itree, element)
                     if eclass == T8_ECLASS_PYRAMID
-                        shape_volume = pyramid_control_volume(scheme, tree_class, element)
+                        shape_volume = pyramid_control_volume(eclass_scheme, element)
                         # WORKAROUND: See `function pyramid_control_volume` for a comment
                         # why the following test is split into two.
                         @test abs(shape_volume - volume) <= epsilon ||

--- a/test/test_all.jl
+++ b/test/test_all.jl
@@ -12,11 +12,6 @@ MPI.Init()
 
 comm = MPI.COMM_WORLD
 
-# Check whether we run CI in the cloud with Windows or Mac, see also
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables
-CI_ON_WINDOWS = (get(ENV, "GITHUB_ACTIONS", false) == "true") && Sys.iswindows()
-CI_ON_MACOS = (get(ENV, "GITHUB_ACTIONS", false) == "true") && Sys.isapple()
-
 @testset "init" begin
     include("test_init.jl")
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,3 +1,4 @@
+
 # This file makes sure to run all examples within the testing suite too.
 # It does not add extra sanity checks, assertions etc. to the examples,
 # but is intended to make sure the examples run without throwing errors.
@@ -24,17 +25,17 @@ end
 
 # Unfortunately, step 5 and step 6 currently crash (1.) in Windows, (2.) in MacOS,
 # and (3.) with Julia older than 1.9, see related issues
-# https://github.com/DLR-AMR/T8code.jl/issues/26,
-# https://github.com/DLR-AMR/T8code.jl/issues/30,
-# https://github.com/DLR-AMR/T8code.jl/issues/104.
+# https://github.com/DLR-AMR/T8code.jl/issues/26, https://github.com/DLR-AMR/T8code.jl/issues/30,
+# and https://github.com/DLR-AMR/T8code.jl/issues/104.
+# Until they are resolved, the two cases are skipped.
 
-@testset "t8_step5_element_data" begin
-    include("../examples/t8_step5_element_data.jl")
-end
+# @testset "t8_step5_element_data" begin
+#     include("../examples/t8_step5_element_data.jl")
+# end
 
-@testset "t8_step6_stencil" begin
-    include("../examples/t8_step6_stencil.jl")
-end
+# @testset "t8_step6_stencil" begin
+#     include("../examples/t8_step6_stencil.jl")
+# end
 
 @testset "t8_tutorial_build_cmesh" begin
     include("../examples/t8_tutorial_build_cmesh.jl")

--- a/test/test_forestwrapper.jl
+++ b/test/test_forestwrapper.jl
@@ -18,7 +18,7 @@
     @test length(T8code.T8CODE_OBJECT_TRACKER) == 0
 
     # Create a forest and wrap by `ForestWrapper`
-    scheme = t8_scheme_new_default()
+    scheme = t8_scheme_new_default_cxx()
     cmesh = t8_cmesh_new_hypercube(T8_ECLASS_QUAD, comm, 0, 0, 0)
     forest = t8_forest_new_uniform(cmesh, scheme, 0, 0, comm)
     wrapper_A = T8code.ForestWrapper(forest)
@@ -26,7 +26,7 @@
     @test length(T8code.T8CODE_OBJECT_TRACKER) == 1
 
     # Create another forest and wrap by `ForestWrapper`
-    scheme = t8_scheme_new_default()
+    scheme = t8_scheme_new_default_cxx()
     cmesh = t8_cmesh_new_hypercube(T8_ECLASS_TRIANGLE, comm, 0, 0, 0)
     forest = t8_forest_new_uniform(cmesh, scheme, 0, 0, comm)
     wrapper_B = T8code.ForestWrapper(forest)


### PR DESCRIPTION
As explained here https://github.com/trixi-framework/Trixi.jl/pull/2706#issuecomment-4338543846, we roll back to the state before https://github.com/DLR-AMR/T8code.jl/pull/105 merged. The reverted version should be released as v0.7.6 to effectively hide the faulty v0.7.5 release.